### PR TITLE
[Releases] Change the sync file to run on release of new version

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,8 +1,8 @@
 name: Sync Files
+# Sync the files to main repo on "release" 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [prereleased, released]
   workflow_dispatch:
 jobs:
   sync:


### PR DESCRIPTION
This will make sure the main repo is maintaned only for stable releases, and will force us to add release notes and versions for folks

To cut a new release, see here https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases

We should start with 0.0.1