### PR TITLE
JobManager: View and skip active iteration

### DIFF
--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -218,7 +218,7 @@ class JobManager:
             return [None, f"Session {session_key} was not running function {func_key}"]
 
         job_info.refresh_active_image_requested.set()
-        if job_info.refresh_active_image_done.wait(timeout=10.0):
+        if job_info.refresh_active_image_done.wait(timeout=20.0):
             job_info.refresh_active_image_done.clear()
             return [gr.Image.update(value=job_info.active_image, visible=True), f"Sample iteration {job_info.active_iteration_cnt}"]
         return [gr.Image.update(visible=False), "Timed out getting image"]

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -292,7 +292,7 @@ class JobManager:
         except Exception as e:
             job_info.job_status = f"Error: {e}"
             print(f"Exception processing job {job_info}: {e}\n{traceback.format_exc()}")
-            outputs = []
+            raise
 
         # Filter the function output for any removed outputs
         filtered_output = []

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -382,6 +382,16 @@ class JobManager:
                 [job_ui._active_image, job_ui._status_text]
             )
 
+        if job_ui._stop_all_session_btn:
+            job_ui._stop_all_session_btn.click(
+                self.stop_all_jobs, [], []
+            )
+
+        if job_ui._free_done_sessions_btn:
+            job_ui._free_done_sessions_btn.click(
+                self.clear_all_finished_jobs, [], []
+            )
+
         # (ab)use gr.JSON to forward events.
         # The gr.JSON object will fire its 'change' event when it is modified by being the output
         # of another component. This allows a method to forward events and allow multiple components

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -132,7 +132,7 @@ class JobManager:
                 with gr.Row():
                     record_steps_checkbox = gr.Checkbox(value=False, label="Enable Batch Progress Grid")
                     record_steps_interval_slider = gr.Slider(
-                        value=3, label="Record Interval (steps)", minimum=1, maximum=25)
+                        value=3, label="Record Interval (steps)", minimum=1, maximum=25, step=1)
                 with gr.Row() as record_steps_box:
                     steps_to_gallery_checkbox = gr.Checkbox(value=False, label="Save Progress Grid to Gallery")
                     steps_to_file_checkbox = gr.Checkbox(value=False, label="Save Progress Grid to File")

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -135,7 +135,7 @@ class JobManager:
                         value=3, label="Record Interval (steps)", minimum=1, maximum=25)
                 with gr.Row() as record_steps_box:
                     steps_to_gallery_checkbox = gr.Checkbox(value=False, label="Save Progress Grid to Gallery")
-                    steps_to_file_checkbox = gr.Checkbox(value=False, label="Save Progress Progress to File")
+                    steps_to_file_checkbox = gr.Checkbox(value=False, label="Save Progress Grid to File")
             with gr.TabItem("Maintenance"):
                 with gr.Row():
                     gr.Markdown(

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -113,7 +113,7 @@ class JobManager:
             with gr.TabItem("Current Session"):
                 with gr.Row():
                     stop_btn = gr.Button("Stop All Batches", elem_id="stop", variant="secondary")
-                    refresh_btn = gr.Button("View Finished Batches", elem_id="refresh", variant="secondary")
+                    refresh_btn = gr.Button("Refresh Finished Batches", elem_id="refresh", variant="secondary")
                 status_text = gr.Textbox(placeholder="Job Status", interactive=False, show_label=False)
                 with gr.Row():
                     active_image_stop_btn = gr.Button("Skip Active Batch", variant="secondary")
@@ -254,7 +254,7 @@ class JobManager:
         return {output_dummy_obj: triggerChangeEvent(),
                 refresh_btn: gr.Button.update(variant="primary", value=refresh_btn.value),
                 stop_btn: gr.Button.update(variant="primary", value=stop_btn.value),
-                status_text: gr.Textbox.update(value="Generation has started. Click 'Refresh' for updates"),
+                status_text: gr.Textbox.update(value="Generation has started. Click 'Refresh' to see finished images, 'View Batch Progress' for active images"),
                 active_refresh_btn: gr.Button.update(variant="primary", value=active_refresh_btn.value),
                 active_stop_btn: gr.Button.update(variant="primary", value=active_stop_btn.value),
                 }

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -149,6 +149,7 @@ class JobManager:
         for session in self._sessions.values():
             for job in session.jobs.values():
                 job.should_stop.set()
+                job.stop_cur_iter.set()
 
     def _get_job_token(self, block: bool = False) -> Optional[int]:
         ''' Attempts to acquire a job token, optionally blocking until available '''

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -327,7 +327,7 @@ class JobManager:
         assert gr.context.Context.block is not None, "wrap_func must be called within a 'gr.Blocks' 'with' context"
 
         # Create a unique key for this job
-        func_key = FuncKey(job_id=uuid.uuid4(), func=func)
+        func_key = FuncKey(job_id=uuid.uuid4().hex, func=func)
 
         # Create a unique session key (next gradio release can use gr.State, see https://gradio.app/state_in_blocks/)
         if self._session_key is None:

--- a/webui.py
+++ b/webui.py
@@ -962,7 +962,8 @@ def process_images(
 
                         # Save the images if recording steps, and append existing saved steps
                         if job_info.rec_steps_enabled:
-                            job_info.rec_steps_imgs.append(grid)
+                            gallery_img_size = tuple( int(0.25*dim) for dim in images[0].size)
+                            job_info.rec_steps_imgs.append(grid.resize(gallery_img_size))
 
                         # Notify the requester that the image is updated
                         if job_info.refresh_active_image_requested.is_set():
@@ -1079,7 +1080,8 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
                 if job_info.rec_steps_enabled and (job_info.rec_steps_to_file or job_info.rec_steps_to_gallery):
                     steps_grid = image_grid(job_info.rec_steps_imgs, 1)
                     if job_info.rec_steps_to_gallery:
-                        output_images.append( steps_grid )
+                        gallery_img_size = tuple(2*dim for dim in image.size)
+                        output_images.append( steps_grid.resize( gallery_img_size ) )
                     if job_info.rec_steps_to_file:
                         steps_grid_filename = f"{original_filename}_step_grid"
                         save_sample(steps_grid, sample_path_i, steps_grid_filename, jpg_sample, prompts, seeds, width, height, steps, cfg_scale,

--- a/webui.py
+++ b/webui.py
@@ -2028,7 +2028,7 @@ txt2img_defaults = {
     'fp': None,
     'variant_amount': 0.0,
     'variant_seed': '',
-    'submit_on_enter': 'Yes',
+    'submit_on_enter': 'No',
 }
 
 if 'txt2img' in user_defaults:

--- a/webui.py
+++ b/webui.py
@@ -951,7 +951,7 @@ def process_images(
                         images: List[Image.Image] = []
                         # Convert tensor to image (copied from code below)
                         for ddim in batch_ddim:
-                            x_sample = 255. * rearrange(batch_ddim[0].cpu().numpy(), 'c h w -> h w c')
+                            x_sample = 255. * rearrange(ddim.cpu().numpy(), 'c h w -> h w c')
                             x_sample = x_sample.astype(np.uint8)
                             image = Image.fromarray(x_sample)
                             images.append(image)

--- a/webui.py
+++ b/webui.py
@@ -2028,7 +2028,7 @@ txt2img_defaults = {
     'fp': None,
     'variant_amount': 0.0,
     'variant_seed': '',
-    'submit_on_enter': 'No',
+    'submit_on_enter': 'Yes',
 }
 
 if 'txt2img' in user_defaults:

--- a/webui.py
+++ b/webui.py
@@ -886,6 +886,7 @@ def process_images(
 
             if job_info:
                 job_info.job_status = f"Processing Iteration {n+1}/{n_iter}. Batch size {batch_size}"
+                job_info.rec_steps_imgs.clear()
                 for idx,(p,s) in enumerate(zip(prompts,seeds)):
                     job_info.job_status += f"\nItem {idx}: Seed {s}\nPrompt: {p}"
 

--- a/webui.py
+++ b/webui.py
@@ -276,7 +276,7 @@ class KDiffusionSampler:
         ''' Converts a KDiffusion callback to the standard img_callback '''
         if callback:
             arg_dict = args[0]
-            callback(image_sample=arg_dict['x'], iter_num=arg_dict['i'])
+            callback(image_sample=arg_dict['denoised'], iter_num=arg_dict['i'])
 
 
 def create_random_tensors(shape, seeds):


### PR DESCRIPTION
Adds buttons to the JobManager dialog to view the actively iterating image batch, or to skip the actively generating image batch and continue with the rest of the batches