### PR TITLE
Fix VectorQuantizer2 problem with taming-transformers

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -33,9 +33,9 @@ dependencies:
     - facexlib>=0.2.3
     - python-slugify>=6.1.2
     - streamlit>=1.12.2
-    - taming-transformers>=0.0.1
     - openai-clip>=1.0.1
     - gfpgan>=1.3.5
     - realesrgan>=0.2.5.0
+    - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/hlky/k-diffusion-sd#egg=k_diffusion
     - -e .


### PR DESCRIPTION
Fixes the following error:

```
ImportError: cannot import name 'VectorQuantizer2' from 'taming.modules.vqvae.quantize'
```

See https://github.com/CompVis/stable-diffusion/issues/72