### PR TITLE
add gfpgan folder to gitignore, auto gen by imglab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ condaenv.*.requirements.txt
 /log/**/*.png
 /log/log.csv
 /flagged/*
+/gfpgan/*


### PR DESCRIPTION
there is a new folder at the root/gfpgan generated and downloaded by gfpgan after Image Lab face fix and upscale has been performed