### PR TITLE
Fix img2img in crop mode

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -299,12 +299,19 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                                                            )
 
                 img2img_func = img2img
+                img2img_func_no_mask = img2img
                 img2img_inputs = [img2img_prompt, img2img_image_editor_mode, img2img_image_editor, img2img_image_mask, img2img_mask,
                                   img2img_mask_blur_strength, img2img_steps, img2img_sampling, img2img_toggles,
                                   img2img_realesrgan_model_name, img2img_batch_count, img2img_cfg,
                                   img2img_denoising, img2img_seed, img2img_height, img2img_width, img2img_resize,
                                   img2img_embeddings]
+                img2img_inputs_no_mask = [img2img_prompt, img2img_image_editor_mode, img2img_image_editor, img2img_image_editor, img2img_mask,
+                                  img2img_mask_blur_strength, img2img_steps, img2img_sampling, img2img_toggles,
+                                  img2img_realesrgan_model_name, img2img_batch_count, img2img_cfg,
+                                  img2img_denoising, img2img_seed, img2img_height, img2img_width, img2img_resize,
+                                  img2img_embeddings]
                 img2img_outputs = [output_img2img_gallery, output_img2img_seed, output_img2img_params, output_img2img_stats]
+                img2img_outputs_no_mask = [output_img2img_gallery, output_img2img_seed, output_img2img_params, output_img2img_stats]
 
                 # If a JobManager was passed in then wrap the Generate functions
                 if img2img_job_ui:
@@ -313,6 +320,11 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                         inputs=img2img_inputs,
                         outputs=img2img_outputs,
                     )
+                    img2img_func_no_mask, img2img_inputs_no_mask, img2img_outputs_no_mask = img2img_job_ui.wrap_func(
+                        func=img2img_func_no_mask,
+                        inputs=img2img_inputs_no_mask,
+                        outputs=img2img_outputs_no_mask,
+                    )
 
                 img2img_btn_mask.click(
                     img2img_func,
@@ -320,9 +332,9 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                     img2img_outputs
                 )
                 def img2img_submit_params():
-                    return (img2img_func,
-                    img2img_inputs,
-                    img2img_outputs)
+                    return (img2img_func_no_mask,
+                    img2img_inputs_no_mask,
+                    img2img_outputs_no_mask)
 
                 img2img_btn_editor.click(*img2img_submit_params())
 


### PR DESCRIPTION
### Reason for change:
Currently img2img requests in the editor crop mode crash with the following exception:
```
x, mask = x["image"], x["mask"]
TypeError: string indices must be integers
```
This happens because the mask editor component (img2img_image_mask) is still sent in crop mode. Gradio then expects a valid gradio component with an image and a mask because img2img_image_mask's tool is set to 'sketch':
```
File "/usr/local/lib/python3.8/site-packages/gradio/components.py", line 1546
        if self.tool == "sketch":
            x, mask = x["image"], x["mask"]
```
Unfortunately in crop mode, the mask editor is invisible and this crashes. 
Maybe the component is only initialized when set to visible? Further research is needed here.
### Change description:
There are already separate 'Generate' buttons for generating images in mask mode and non mask mode.

I've introduced a new set of inputs called img2img_inputs_no_mask, which do not send the mask.
Then I've changed the button for non mask mode to send these inputs, as the mask is not needed for non mask modes anyway. 

In place of the mask I send the image **again**. This is not the best solution, but does not break the function definition, as it is another gradio image component. Optimally another img2img function should probably be introduced which skips the mask parameter entirely.