### PR TITLE
Better support for large batches in optimized mode

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -34,8 +34,11 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                                                 value=txt2img_defaults['cfg_scale'], elem_id='cfg_slider')
                         txt2img_seed = gr.Textbox(label="Seed (blank to randomize)", lines=1, max_lines=1,
                                                   value=txt2img_defaults["seed"])
+                        txt2img_batch_size = gr.Slider(minimum=1, maximum=50, step=1,
+                                                       label='Images per batch',
+                                                       value=txt2img_defaults['batch_size'])
                         txt2img_batch_count = gr.Slider(minimum=1, maximum=50, step=1,
-                                                        label='Number of images to generate',
+                                                        label='Number of batches to generate',
                                                         value=txt2img_defaults['n_iter'])
 
                         txt2img_job_ui = job_manager.draw_gradio_ui() if job_manager else None
@@ -86,9 +89,6 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                             with gr.TabItem('Advanced'):
                                 txt2img_toggles = gr.CheckboxGroup(label='', choices=txt2img_toggles,
                                                                    value=txt2img_toggle_defaults, type="index")
-                                txt2img_batch_size = gr.Slider(minimum=1, maximum=8, step=1,
-                                                               label='Batch size (how many images are in a batch; memory-hungry)',
-                                                               value=txt2img_defaults['batch_size'])
                                 txt2img_realesrgan_model_name = gr.Dropdown(label='RealESRGAN model',
                                                                             choices=['RealESRGAN_x4plus',
                                                                                      'RealESRGAN_x4plus_anime_6B'],

--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -940,11 +940,10 @@ def process_images(
             if opt.optimized:
                 modelFS.to(device)
 
+            for i in range(len(samples_ddim)):
+                x_samples_ddim = (model if not opt.optimized else modelFS).decode_first_stage(samples_ddim[i].unsqueeze(0))
+                x_sample = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
 
-
-            x_samples_ddim = (model if not opt.optimized else modelFS).decode_first_stage(samples_ddim)
-            x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
-            for i, x_sample in enumerate(x_samples_ddim):
                 sanitized_prompt = prompts[i].replace(' ', '_').translate({ord(x): '' for x in invalid_filename_chars})
                 if variant_seed != None and variant_seed != '':
                     if variant_amount == 0.0:
@@ -965,7 +964,7 @@ def process_images(
                     sanitized_prompt = sanitized_prompt
                     filename = f"{base_count:05}-{steps}_{sampler_name}_{seed_used}_{cur_variant_amount:.2f}_{sanitized_prompt}"[:128] #same as before
 
-                x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
+                x_sample = 255. * rearrange(x_sample[0].cpu().numpy(), 'c h w -> h w c')
                 x_sample = x_sample.astype(np.uint8)
                 image = Image.fromarray(x_sample)
                 original_sample = x_sample


### PR DESCRIPTION
Larger batches reduce inference time per image, at cost of VRAM, as explained in [the optimized SD repo](https://github.com/basujindal/stable-diffusion#--n_samples).

On my machine (3060 ti, 8gb VRAM), this lets me run a batch of 50 images at once with 20 steps of DDIM under 4 minutes, with VRAM to spare. Non-optimized with smaller batches would take much longer.

This PR fixes an issue where diffusion completes successfully, but decoding runs out of memory due to batching. Instead, we decode each image by itself. The logic was picked up from the optimized SD code base.

As such, the "images per batch" slider is moved to a more prominent location, and accepts more values.