### PR TITLE
Fix typo in readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/altryne/sd-webui-colab/blob/main/Stable_Diffusion_WebUi_Altryne.ipynb)
 
-# [Installation](https://github.com/sd-webui/stable-diffusion-webui/wiki/Installation)
+# [Installation](https://github.com/sd-webui/stable-diffusion-webui/wiki/INSTALLATION)
 
 ### Have an **issue**? 
 


### PR DESCRIPTION
The installation  link in the readme.md is in lower case, while the wiki file is capitals. This leads to a dead link. Fixed.