### PR TITLE
Bugfix for old repo issue 219 -- txt2img aspect ratio box doesn't update

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -130,8 +130,8 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x,imgproc=lambda 
                     txt2img_outputs
                 )
 
-                # txt2img_width.change(fn=uifn.update_dimensions_info, inputs=[txt2img_width, txt2img_height], outputs=txt2img_dimensions_info_text_box)
-                # txt2img_height.change(fn=uifn.update_dimensions_info, inputs=[txt2img_width, txt2img_height], outputs=txt2img_dimensions_info_text_box)
+                txt2img_width.change(fn=uifn.update_dimensions_info, inputs=[txt2img_width, txt2img_height], outputs=txt2img_dimensions_info_text_box)
+                txt2img_height.change(fn=uifn.update_dimensions_info, inputs=[txt2img_width, txt2img_height], outputs=txt2img_dimensions_info_text_box)
 
                 live_prompt_params = [txt2img_prompt, txt2img_width, txt2img_height, txt2img_steps, txt2img_seed, txt2img_batch_count, txt2img_cfg]
                 txt2img_prompt.change(


### PR DESCRIPTION
This is a fix for the aspect ratio box being broken (on master and dev). The sliders should cause the aspect ratio info to fill in, but doesn't for txt2img.

The old issue got closed, so I decided to look for a fix and noticed the code was just commented out.

https://github.com/sd-webui/stable-diffusion/issues/219