### PR TITLE
Use mamba instead of conda

### DIFF
--- a/webui.cmd
+++ b/webui.cmd
@@ -1,6 +1,15 @@
 @echo off
 
 set conda_env_name=ldm
+set conda_command=conda
+
+set use_mamba_instead_of_conda=1
+if "%use_mamba_instead_of_conda%"=="1" (
+  where /q mamba
+  if errorlevel 0 echo mamba installed
+  if errorlevel 1 conda install mamba -n base -c conda-forge
+  set conda_command=mamba
+)
 
 :: Put the path to conda directory after "=" sign if it's installed at non-standard path:
 set custom_conda_path=
@@ -37,15 +46,20 @@ IF "%CONDA_PATH%"=="" (
 
 :foundPath
 call "%CONDA_PATH%\Scripts\activate.bat"
-call conda env create -n "%conda_env_name%" -f environment.yaml
-call conda env update -n "%conda_env_name%" --file environment.yaml --prune
+%conda_command% env list | findstr /r /b /c:"%conda_env_name%"
+if errorlevel 0 goto :conda_env_update
+if errorlevel 1 goto :conda_env_create
+goto :eof
+
+:conda_env_create
+call %conda_command% env create --name "%conda_env_name%" --file environment.yaml
+goto :conda_activate
+
+:conda_env_update
+call %conda_command% env update --name "%conda_env_name%" --file environment.yaml --prune
+goto :conda_activate
+
+:conda_activate
 call "%CONDA_PATH%\Scripts\activate.bat" "%conda_env_name%"
 python "%CD%"\scripts\relauncher.py
-
-:PROMPT
-set SETUPTOOLS_USE_DISTUTILS=stdlib
-IF EXIST "models\ldm\stable-diffusion-v1\model.ckpt" (
-  python scripts/relauncher.py
-) ELSE (
-  ECHO Your model file does not exist! Place it in 'models\ldm\stable-diffusion-v1' with the name 'model.ckpt'.
-)
+goto :eof


### PR DESCRIPTION
I had some problems with conda, so I added the possibilty to use [mamba](https://github.com/mamba-org/mamba), which is a more stable and faster drop-in replacement for the `conda` command written in C++. I changed `Webui.cmd` so that by default it installs and/or uses Mamba. This can be easily disabled by changing line 6 from:

```bat
set use_mamba_instead_of_conda=1
```

to 

```bat
set use_mamba_instead_of_conda=0
```

Also, I tweaked `webui.cmd` a bit so that creating and updating the environment doesn't happen one after the other (because it doesn't make sense) and removed the dead code at the end.