### PR TITLE
This change allows Lists of Prompts to be processed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Visual Studio Garbage
+/.vs
+
 # Distribution / packaging
 .Python
 build/

--- a/configs/webui/webui.yaml
+++ b/configs/webui/webui.yaml
@@ -10,10 +10,11 @@ txt2img:
   #  3:  Save grid
   #  4:  Sort samples by prompt
   #  5:  Write sample info files
-  #  6:  write sample info to log file
+  #  6:  Write sample info to log file
   #  7:  jpg samples
-  #  8:  Fix faces using GFPGAN
-  #  9:  Upscale images using RealESRGAN
+  #  8:  Iterate seed every line when processing prompt lists
+  #  9:  Fix faces using GFPGAN
+  # 10:  Upscale images using RealESRGAN
   toggles: [1, 2, 3, 4, 5]
   sampler_name: k_lms
   ddim_eta: 0.0  # legacy name, applies to all algorithms.

--- a/frontend/ui_functions.py
+++ b/frontend/ui_functions.py
@@ -5,8 +5,7 @@ from io import BytesIO
 import base64
 import re
 
-
-def change_image_editor_mode(choice, cropped_image, masked_image, resize_mode, width, height):
+def change_image_editor_mode(choice, cropped_image, resize_mode, width, height):
     if choice == "Mask":
         update_image_result = update_image_mask(cropped_image, resize_mode, width, height)
         return [gr.update(visible=False), update_image_result, gr.update(visible=False), gr.update(visible=True), gr.update(visible=False), gr.update(visible=True), gr.update(visible=True)]
@@ -16,7 +15,7 @@ def change_image_editor_mode(choice, cropped_image, masked_image, resize_mode, w
 
 def update_image_mask(cropped_image, resize_mode, width, height):
     resized_cropped_image = resize_image(resize_mode, cropped_image, width, height) if cropped_image else None
-    return gr.update(value=resized_cropped_image, visible=True)
+    return gr.update(value=resized_cropped_image)
 
 def toggle_options_gfpgan(selection):
     if 0 in selection:
@@ -217,3 +216,18 @@ def load_settings(*values):
         values[cbg_index] = [cbg_choices[i] for i in values[cbg_index]]
 
     return values
+
+def clear_promptlist_filepath(txt2img_promptlist_filepath):
+    return "Upload a text file: each line will be processed once per batch."
+
+def change_promptlist_filepath(txt2img_promptlist_filepath):
+    if (txt2img_promptlist_filepath is None or txt2img_promptlist_filepath.name is None):
+        return gr.TextArea.update(), "Upload a text file: each line will be processed once per batch.", gr.Tabs.update()
+    
+    with open(txt2img_promptlist_filepath.name) as f:
+        prompts = [line.rstrip() for line in f]
+
+    processed_textarea = "\n".join(prompts)
+    processed_markdown = "File parsed, " + str(len(prompts)) + " prompts loaded."
+    tabs_update = gr.Tabs.update(selected='tab_promptlist_textbox')
+    return processed_textarea, processed_markdown, tabs_update


### PR DESCRIPTION
![Prompt List](https://user-images.githubusercontent.com/53918474/189068131-6d5be523-3a82-4af6-ae63-5ed1e9a60093.png)

This change allows lists of prompts to be processed.  The list can be typed/pasted into a textbox or loaded from a text file (which populated the textbox). The existing "Image Count" slider allows the list to be processed multiple times. Set it to 10 and run it against 9 prompts, and you'll get 90 images.

I also added an option under advanced to allow the seed to be kept the same while processing the list or to be iterated. If the option is disabled, we still iterate, but only after processing the whole list. This is useful if you want a list of prompts run against the same seed, such as when trying minor changes to a prompt.

In the future, it'd be nice to parse arguments, so that each prompt could specify sampling steps, diffuser, etc, similar to what the log writes out. (Size would be nice as well, but that would get messy with grid generation).

I tried to keep the change as clean as possible. I did have to refactor process_images to accept multiple prompts, which seemed better than making a second version that had to be maintained.  I also ignore the multi-prompt setting, as that would get complicated, quickly, and also because in general, I imagine prompt lists to be used for things that are a little too complicated for the two types of multi-prompt.

Thanks, and thanks for all the work in maintaining all this!
