### PR TITLE
Send preview image of current step during job refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ condaenv.*.requirements.txt
 /log/log.csv
 /flagged/*
 /gfpgan/*
+.vscode
+src/

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -30,6 +30,7 @@ class JobInfo:
     session_key: str
     job_token: Optional[int] = None
     images: List[Image] = field(default_factory=list)
+    current_preview: Optional[Image] = None
     should_stop: Event = field(default_factory=Event)
     job_status: str = field(default_factory=str)
     finished: bool = False
@@ -273,7 +274,11 @@ class JobManager:
         if job_info.finished:
             session_info.finished_jobs.pop(func_key)
 
-        return job_info.images
+        in_progress_images = job_info.images
+        if job_info.current_preview and not job_info.finished:
+            in_progress_images = job_info.images.copy()
+            in_progress_images.append(job_info.current_preview)
+        return in_progress_images
 
     def _wrap_func(
             self, func: Callable, inputs: List[Component], outputs: List[Component],


### PR DESCRIPTION
These changes will send a preview image of the current step to the gallery when clicking on the Job Refresh button in the Gradio interface.  This allows you to get immediate feedback during a generation of an image with a lot of steps, and its cool to see how the model evolves the image over time.  Most of this work was taken from the webui_streamlit code.