### PR TITLE
Fixed missing diffusers dependency for Streamlit

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -33,6 +33,7 @@ dependencies:
     - python-slugify>=6.1.2
     - streamlit>=1.12.2
     - retry>=0.9.2
+    - diffusers>=0.3.0
     - -e git+https://github.com/CompVis/taming-transformers#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP#egg=clip
     - -e git+https://github.com/TencentARC/GFPGAN#egg=GFPGAN


### PR DESCRIPTION
This should fix the missing diffusers dependency error when first launching. :)