### PR TITLE
Changed Streamit yaml default configs

### DIFF
--- a/configs/webui/webui_streamlit.yaml
+++ b/configs/webui/webui_streamlit.yaml
@@ -7,7 +7,7 @@ general:
     default_model_config: "configs/stable-diffusion/v1-inference.yaml"
     default_model_path: "models/ldm/stable-diffusion-v1/model.ckpt"
     fp:
-        name: 'embeddings/alex/embeddings_gs-11000.pt'
+        name: ''
     GFPGAN_dir: "./src/gfpgan"
     RealESRGAN_dir: "./src/realesrgan"
     RealESRGAN_model: "RealESRGAN_x4plus"

--- a/configs/webui/webui_streamlit.yaml
+++ b/configs/webui/webui_streamlit.yaml
@@ -28,7 +28,7 @@ general:
     optimized: False
     optimized_turbo: False
     update_preview: True
-    update_preview_frequency: 1
+    update_preview_frequency: 5
 
 txt2img:
     prompt:
@@ -46,8 +46,8 @@ txt2img:
     save_grid: True
     group_by_prompt: True
     save_as_jpg: False
-    use_GFPGAN: True
-    use_RealESRGAN: True
+    use_GFPGAN: False
+    use_RealESRGAN: False
     RealESRGAN_model: "RealESRGAN_x4plus"
     variant_amount: 0.0
     variant_seed: ""
@@ -70,7 +70,7 @@ txt2vid:
     group_by_prompt: True
     save_as_jpg: False
     use_GFPGAN: False
-    use_RealESRGAN: True
+    use_RealESRGAN: False
     RealESRGAN_model: "RealESRGAN_x4plus"
     variant_amount: 0.0
     variant_seed: ""
@@ -118,8 +118,8 @@ img2img:
   save_grid: True
   group_by_prompt: True
   save_as_jpg: False
-  use_GFPGAN: True
-  use_RealESRGAN: True
+  use_GFPGAN: False
+  use_RealESRGAN: False
   RealESRGAN_model: "RealESRGAN_x4plus"
   variant_amount: 0.0
   variant_seed: ""


### PR DESCRIPTION
Changed `update_preview_frequency` from every 1 step to every 5 steps. This results in a massive gain in performance (roughly going from 2-3 times slower to only 10-15% slower) while still showing good image generation output.

Changed default GFPGAN and realESRGAN settings to be off by default. That way, users can decide if they want to use them on, and what images they wish to do so.