### PR TITLE
Output stats

### DIFF
--- a/scripts/webui_streamlit.py
+++ b/scripts/webui_streamlit.py
@@ -1862,7 +1862,7 @@ def layout():
 					                                           save_grid, group_by_prompt, save_as_jpg, use_GFPGAN, use_RealESRGAN, RealESRGAN_model, fp=defaults.general.fp,
 					                                           variant_amount=variant_amount, variant_seed=variant_seed, write_info_files=write_info_files)
 				
-					message.success('Done!', icon="✅")
+					message.success('Render Complete: ' + info + '; Stats: ' + stats, icon="✅")
 
 				except KeyError:
 					output_images, seed, info, stats = txt2img(prompt, st.session_state.sampling_steps, sampler_name, RealESRGAN_model, batch_count, 1, 
@@ -1870,7 +1870,7 @@ def layout():
 					                                           save_grid, group_by_prompt, save_as_jpg, use_GFPGAN, use_RealESRGAN, RealESRGAN_model, fp=defaults.general.fp,
 					                                           variant_amount=variant_amount, variant_seed=variant_seed, write_info_files=write_info_files)
 				
-					message.success('Done!', icon="✅")
+					message.success('Render Complete: ' + info + '; Stats: ' + stats, icon="✅")
 					
 				except (StopException):
 					print(f"Received Streamlit StopException")

--- a/scripts/webui_streamlit.py
+++ b/scripts/webui_streamlit.py
@@ -2018,7 +2018,7 @@ def layout():
 											   )
 	
 						#show a message when the generation is complete.
-						message.success('Done!', icon="✅")
+						message.success('Render Complete: ' + info + '; Stats: ' + stats, icon="✅")
 
 					except (StopException, KeyError):
 						print(f"Received Streamlit StopException")


### PR DESCRIPTION
This is a very simple change to add the stats and info to the success message, matching Gradio behavior (although without the fancy formatting) which is useful for, among other things, copying the seed from the last generated image.

![image](https://user-images.githubusercontent.com/53918474/189308840-f6ad1e8c-6433-4e68-9ef0-4cfc32e67ee6.png)
