### PR TITLE
Urgent fix to remove whitespace in conda env name

### DIFF
--- a/webui-streamlit.cmd
+++ b/webui-streamlit.cmd
@@ -2,7 +2,9 @@
 
 :: copy over the first line from environment.yaml, e.g. name: ldm, and take the second word after splitting by ":" delimiter 
 set /p first_line=< environment.yaml  
-for /f "tokens=2 delims=:" %%i in ("%first_line%") do set conda_env_name=%%i
+for /f "tokens=2 delims=:" %%i in ("%first_line%") do set untrimmed_conda_env_name=%%i
+:: remove whitespaces
+for /f "tokens=* delims= " %%a in ("%untrimmed_conda_env_name%") do set conda_env_name=%%a
 echo Environment name is set as %conda_env_name% as per environment.yaml
 
 :: Put the path to conda directory after "=" sign if it's installed at non-standard path:

--- a/webui.cmd
+++ b/webui.cmd
@@ -2,7 +2,9 @@
 
 :: copy over the first line from environment.yaml, e.g. name: ldm, and take the second word after splitting by ":" delimiter 
 set /p first_line=< environment.yaml  
-for /f "tokens=2 delims=:" %%i in ("%first_line%") do set conda_env_name=%%i
+for /f "tokens=2 delims=:" %%i in ("%first_line%") do set untrimmed_conda_env_name=%%i
+:: remove whitespaces
+for /f "tokens=* delims= " %%a in ("%untrimmed_conda_env_name%") do set conda_env_name=%%a
 echo Environment name is set as %conda_env_name% as per environment.yaml
 
 :: Put the path to conda directory after "=" sign if it's installed at non-standard path:


### PR DESCRIPTION
Fixing bugs introduce in #860, due to trailing whitespace. Urgent since it is breaking changes