### PR TITLE
Added CSS to center the image in the txt2img interface

### DIFF
--- a/frontend/css/streamlit.main.css
+++ b/frontend/css/streamlit.main.css
@@ -13,3 +13,6 @@
 button[data-baseweb="tab"] {
   font-size: 25px;
 }
+.css-du1fp8 {
+    justify-content: center;
+}


### PR DESCRIPTION
@ZeroCool940711 requested some CSS to center the image on the txt2img tab.

This PR fixes it using `justify-content: center;` added to the appropriate class in the streamlit CSS file.