### PR TITLE
Add filename formatting argument

### DIFF
--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -32,7 +32,7 @@ parser.add_argument("--outdir_img2img", type=str, nargs="?", help="dir to write 
 parser.add_argument("--outdir_imglab", type=str, nargs="?", help="dir to write imglab results to (overrides --outdir)", default=None)
 parser.add_argument("--outdir_txt2img", type=str, nargs="?", help="dir to write txt2img results to (overrides --outdir)", default=None)
 parser.add_argument("--outdir", type=str, nargs="?", help="dir to write results to", default=None)
-parser.add_argument("--name_format", type=str, nargs="?", help="filenames format", default=None)
+parser.add_argument("--filename_format", type=str, nargs="?", help="filenames format", default=None)
 parser.add_argument("--port", type=int, help="choose the port for the gradio webserver to use", default=7860)
 parser.add_argument("--precision", type=str, help="evaluate at this precision", choices=["full", "autocast"], default="autocast")
 parser.add_argument("--realesrgan-dir", type=str, help="RealESRGAN directory", default=('./src/realesrgan' if os.path.exists('./src/realesrgan') else './RealESRGAN'))


### PR DESCRIPTION
Make the filenames format configurable with a "--filename_format" argument.

All parameters vary depending on our needs and experiments. Some people play a lot with steps, others with CFG, or image dimensions. And it is very handy to have this information in the filenames. Personally, I have to manually change webui.py every time I update the repo, to fit my needs. The best way to make everyone happy is to make the filenames format configurable with a "--name_format" argument. Using tags is the most flexible and scalable way. Something like:

`--filename_format [STEPS]_[CFG]_[SEED]_[PROMPT]`

The supported tags in the name format are: [STEPS], [CFG], [PROMPT], [PROMPT_SPACES], [WIDTH], [HEIGHT], [SAMPLER], [VARIANT_AMOUNT] and [SEED]. If no format is provided as an argument, it will use the current naming format.

[PROMPT_SPACES] is the same thing as [PROMPT], except that spaces are not replaced by underscores, making copying and pasting prompts from filenames easier.

_(special thanks to Samson for the help with my first PR)_