### PR TITLE
Tiling parameter

### DIFF
--- a/scripts/relauncher.py
+++ b/scripts/relauncher.py
@@ -19,6 +19,8 @@ optimized_turbo = False
 # Creates a public xxxxx.gradio.app share link to allow others to use your interface (requires properly forwarded ports to work correctly)
 share = False
 
+# Generate tiling images
+tiling = True
 
 # Enter other `--arguments` you wish to use - Must be entered as a `--argument ` syntax
 additional_arguments = ""
@@ -37,6 +39,8 @@ if optimized_turbo == True:
     common_arguments += "--optimized-turbo "
 if optimized == True:
     common_arguments += "--optimized "
+if tiling == True:
+    common_arguments += "--tiling "
 if share == True:
     common_arguments += "--share "
 

--- a/scripts/relauncher.py
+++ b/scripts/relauncher.py
@@ -20,7 +20,7 @@ optimized_turbo = False
 share = False
 
 # Generate tiling images
-tiling = True
+tiling = False
 
 # Enter other `--arguments` you wish to use - Must be entered as a `--argument ` syntax
 additional_arguments = ""


### PR DESCRIPTION
I added a --tiling parameter which patches all models to use padding_mode='circular'. This causes SD to generate tiling images natively, in one go, without extra processing.

![image](https://user-images.githubusercontent.com/2590984/189399357-7c8b6767-450e-4c96-8b31-6f0564bf125b.png)

More images here https://www.reddit.com/r/StableDiffusion/comments/x5q7no/native_seamless_tile_generation_no_inpainting/

It's a parameter because it requires the models to be reinitialized (as far as I know) so you need to restart anyways. The UI could be modified to reinitialize the model on demand. That would be a desperate PR and it could include the --optimized flag etc.

Code modified from https://gitlab.com/-/snippets/2395088