### PR TITLE
Image transparency can be used as mask for inpainting

### DIFF
--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -79,7 +79,6 @@ from contextlib import contextmanager, nullcontext
 from einops import rearrange, repeat
 from itertools import islice
 from omegaconf import OmegaConf
-from PIL import Image, ImageFont, ImageDraw, ImageFilter, ImageOps
 from io import BytesIO
 import base64
 import re
@@ -1364,10 +1363,12 @@ def img2img(prompt: str, image_editor_mode: str, mask_mode: str, mask_blur_stren
 
     if image_editor_mode == 'Mask':
         init_img = init_info_mask["image"]
+        init_img_transparency = ImageOps.invert(init_img.split()[-1]).convert('L').point(lambda x: 255 if x > 0 else 0, mode='1')
         init_img = init_img.convert("RGB")
         init_img = resize_image(resize_mode, init_img, width, height)
         init_img = init_img.convert("RGB")
         init_mask = init_info_mask["mask"]
+        init_mask = ImageChops.lighter(init_img_transparency, init_mask.convert('L')).convert('RGBA')
         init_mask = init_mask.convert("RGB")
         init_mask = resize_image(resize_mode, init_mask, width, height)
         init_mask = init_mask.convert("RGB")


### PR DESCRIPTION
This PR is based on https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/124 by @fuzzytent, which is a feature I've found very useful. The Gradio sketch tool leaves a lot to be desired.

I'll quote fuzzytent's notes about the code:

> If you add an image with an alpha channel to img2img, it is also used for masking. This lets you do the masking with a proper image editor instead of the terrible Gradio one.

> Any pixel with any transparency is treated as part of the mask, so partial transparency doesn't create a partial mask. But it is useful for editors that do not save color information in completely transparent areas.

> If you use both an alpha channel and the Gradio mask they are combined.

I'll also add an important note, which is that the level of transparency affects how inpainting is applied to a given region.

An inpainted region that is 50% transparent will have its content used by the inpainting algorithm when it fills that space, while a region that is 100% transparent will treated as though the original image had pure-white pixels with no contextual information about what was previously in that space.

My sense is that the former is much better for getting accurate inpainting results, but both have pros and cons.