### PR TITLE
Add LDSR as conda dependency

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -38,4 +38,5 @@ dependencies:
     - -e git+https://github.com/TencentARC/GFPGAN#egg=GFPGAN
     - -e git+https://github.com/xinntao/Real-ESRGAN#egg=realesrgan
     - -e git+https://github.com/hlky/k-diffusion-sd#egg=k_diffusion
+    - -e git+https://github.com/devilismyfriend/latent-diffusion#egg=latent-diffusion
     - -e .

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='latent-diffusion',
+    name='sd-webui',
     version='0.0.1',
     description='',
     packages=find_packages(),


### PR DESCRIPTION
The `setup.py` included in this respository was preventing the egg https://github.com/devilismyfriend/latent-diffusion from being loaded. I renamed to mach this organization and tested txt2img, img2img as well as tested LDSR in image lab.