### PR TITLE
remove deprecated kwargs/parameter

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -402,8 +402,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                             #                            value=gfpgan_defaults['strength'])
                             # select folder with images to process
                             with gr.TabItem('Batch Process'):
-                                imgproc_folder = gr.File(label="Batch Process", file_count="multiple", source="upload",
-                                                         interactive=True, type="file")
+                                imgproc_folder = gr.File(label="Batch Process", file_count="multiple", interactive=True, type="file")
                         imgproc_pngnfo = gr.Textbox(label="PNG Metadata", placeholder="PngNfo", visible=False,
                                                     max_lines=5)
                         with gr.Row():


### PR DESCRIPTION
Credit to @[akx](https://github.com/akx) [PR](https://github.com/sd-webui/stable-diffusion-webui/pull/663/commits/e54a1668c986f3b84a67095a1e051e84a5e66e00) which was unfortunately un-merged during migration from hlky to sd-webui. I don't know how to perform git cherry pick from another repo and branch unfortunately so resubmitting a new PR here.

Reference documentation to confirm gr.File no longer has `source` is [here](https://gradio.app/docs/#file).

 This remove the following error warning when starting the project.
`\.conda\envs\ldm\lib\site-packages\gradio\deprecation.py:43: UserWarning: You have unused kwarg parameters in File, please remove them: {'source': 'upload'}`

What it looks like now.
![image](https://user-images.githubusercontent.com/3688500/189507736-e6dabc10-3626-4c6b-ac8e-86fcd5355876.png)
