### PR TITLE
Update util.py

### DIFF
--- a/ldm/modules/diffusionmodules/util.py
+++ b/ldm/modules/diffusionmodules/util.py
@@ -54,7 +54,8 @@ def make_ddim_timesteps(ddim_discr_method, num_ddim_timesteps, num_ddpm_timestep
 
     # assert ddim_timesteps.shape[0] == num_ddim_timesteps
     # add one to get the final alpha values right (the ones from first scale to data during sampling)
-    steps_out = ddim_timesteps + 1
+    # steps_out = ddim_timesteps + 1 # removed due to some issues when reaching 1000
+    steps_out = np.where(ddim_timesteps != 999, ddim_timesteps+1, ddim_timesteps)
     if verbose:
         print(f'Selected timesteps for ddim sampler: {steps_out}')
     return steps_out


### PR DESCRIPTION
This is a quick and dirty to fix to the issue with sampling steps for DDIM and PLMS.
Both samplers use the same code to generate steps_out.
This will lead to an error if the array contains a numer 1000.
By changing the line creating the numer 1000 I work around the issue, which in the first place I do not understand any further then how to work around it like this.
The workaround has a side effect which will user 10 sample steps instead of 9 since 9 creates the error, or it uses 112 steps instead of 107 as again 107 would create the error like 111 too.
I found this as a possible fix at this link, so it is not my original work or idea :)
https://pullanswer.com/questions/indexerror-index-1000-is-out-of-bounds-for-dimension-0-with-size-1000