### PR TITLE
Update docker commands with new repo name

### DIFF
--- a/docker-reset.sh
+++ b/docker-reset.sh
@@ -10,9 +10,9 @@ echo $(pwd)
 read -p "Is the directory above correct to run reset on? (y/n) " -n 1 DIRCONFIRM
 if [[ $DIRCONFIRM =~ ^[Yy]$ ]]; then
     docker compose down
-    docker image rm stable-diffusion_stable-diffusion:latest
-    docker volume rm stable-diffusion_conda_env
-    docker volume rm stable-diffusion_root_profile
+    docker image rm stable-diffusion-webui-stable-diffusion:latest
+    docker volume rm stable-diffusion-webui_conda_env
+    docker volume rm stable-diffusion-webui_root_profile
     echo "Remove ./src"
     sudo rm -rf src
     sudo rm -rf latent_diffusion.egg-info


### PR DESCRIPTION
The current docker-reset.sh script uses docker commands referencing the old repo names and therefore will run unsuccessfully but without throwing any errors. This script should now reset the docker environment.