### PR TITLE
Docker - Set PYTHONPATH to parent directory to avoid `No module named frontend` error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
+export PYTHONPATH=$SCRIPT_DIR
 
 MODEL_DIR="${SCRIPT_DIR}/model_cache"
 # Array of model files to pre-download
@@ -31,6 +32,7 @@ ENV_UPDATED=0
 ENV_MODIFIED=$(date -r $ENV_FILE "+%s")
 ENV_MODIFED_FILE="${SCRIPT_DIR}/.env_updated"
 if [[ -f $ENV_MODIFED_FILE ]]; then ENV_MODIFIED_CACHED=$(<${ENV_MODIFED_FILE}); else ENV_MODIFIED_CACHED=0; fi
+export PIP_EXISTS_ACTION=w
 
 # Create/update conda env if needed
 if ! conda env list | grep ".*${ENV_NAME}.*" >/dev/null 2>&1; then


### PR DESCRIPTION
Also set `PIP_EXISTS_ACTION=w` env variable for conda to avoid interaction during setup