### PR TITLE
Animation generating with ~ tilde prompt in txt2img

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ condaenv.*.requirements.txt
 /log/log.csv
 /flagged/*
 /gfpgan/*
+
+# Needed for mp4 encoding in windows.
+openh264-1.8.0-win64.dll

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -36,7 +36,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                                                 value=txt2img_defaults['cfg_scale'], elem_id='cfg_slider')
                         txt2img_seed = gr.Textbox(label="Seed (blank to randomize)", lines=1, max_lines=1,
                                                   value=txt2img_defaults["seed"])
-                        txt2img_batch_count = gr.Slider(minimum=1, maximum=50, step=1,
+                        txt2img_batch_count = gr.Slider(minimum=1, maximum=256, step=1,
                                                         label='Number of images to generate',
                                                         value=txt2img_defaults['n_iter'])
 
@@ -46,19 +46,21 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                             label="Aspect ratio (4:3 = 1.333 | 16:9 = 1.777 | 21:9 = 2.333)")
                     with gr.Column():
                         with gr.Box():
-                            output_txt2img_gallery = gr.Gallery(label="Images", elem_id="txt2img_gallery_output").style(
-                                grid=[4, 4])
-                            gr.Markdown(
-                                "Select an image from the gallery, then click one of the buttons below to perform an action.")
-                            with gr.Row(elem_id='txt2img_actions_row'):
-                                gr.Button("Copy to clipboard").click(fn=None,
-                                                                     inputs=output_txt2img_gallery,
-                                                                     outputs=[],
-                                                                     # _js=js_copy_to_clipboard( 'txt2img_gallery_output')
-                                                                     )
-                                output_txt2img_copy_to_input_btn = gr.Button("Push to img2img")
-                                output_txt2img_to_imglab = gr.Button("Send to Lab", visible=True)
-
+                            with gr.Tabs(elem_id='tabs_gallery') as tabs_gallery:
+                                with gr.TabItem("Images", id='images_tab'):
+                                    output_txt2img_gallery = gr.Gallery(label="Images", elem_id="txt2img_gallery_output").style(grid=[4, 4])
+                                    gr.Markdown("Select an image from the gallery, then click one of the buttons below to perform an action.")
+                                    with gr.Row(elem_id='txt2img_actions_row'):
+                                        gr.Button("Copy to clipboard").click(fn=None,
+                                                inputs=output_txt2img_gallery,
+                                                outputs=[],
+                                                #_js=js_copy_to_clipboard( 'txt2img_gallery_output')
+                                                )
+                                        output_txt2img_copy_to_input_btn = gr.Button("Push to img2img")
+                                        output_txt2img_to_imglab = gr.Button("Send to Lab",visible=True)
+                                with gr.TabItem("Videos", id='videos_tab'):
+                                    output_txt2img_video = gr.Video(interactive=False)       
+                                    
                         output_txt2img_params = gr.Highlightedtext(label="Generation parameters", interactive=False,
                                                                    elem_id='highlight')
                         with gr.Group():
@@ -114,7 +116,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                                   txt2img_realesrgan_model_name, txt2img_ddim_eta, txt2img_batch_count,
                                   txt2img_batch_size, txt2img_cfg, txt2img_seed, txt2img_height, txt2img_width,
                                   txt2img_embeddings, txt2img_variant_amount, txt2img_variant_seed]
-                txt2img_outputs = [output_txt2img_gallery, output_txt2img_seed,
+                txt2img_outputs = [output_txt2img_gallery, output_txt2img_video, output_txt2img_seed,
                                    output_txt2img_params, output_txt2img_stats]
 
                 # If a JobManager was passed in then wrap the Generate functions

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -108,6 +108,10 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                                                                    value=txt2img_defaults['variant_amount'])
                                 txt2img_variant_seed = gr.Textbox(label="Variant Seed (blank to randomize)", lines=1,
                                                                   max_lines=1, value=txt2img_defaults["variant_seed"])
+                                txt2img_animation_steps = gr.Textbox(label="Animation steps (list separated by , as in 1,2,3)", lines=1,
+                                                                  max_lines=1, value=txt2img_defaults["variant_seed"])
+                                txt2img_animation_levels = gr.Textbox(label="Animation levels (list separated by , as in 1,2,3)", lines=1,
+                                                                  max_lines=1, value=txt2img_defaults["variant_seed"])
                         txt2img_embeddings = gr.File(label="Embeddings file for textual inversion",
                                                      visible=show_embeddings)
 
@@ -115,7 +119,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                 txt2img_inputs = [txt2img_prompt, txt2img_steps, txt2img_sampling, txt2img_toggles,
                                   txt2img_realesrgan_model_name, txt2img_ddim_eta, txt2img_batch_count,
                                   txt2img_batch_size, txt2img_cfg, txt2img_seed, txt2img_height, txt2img_width,
-                                  txt2img_embeddings, txt2img_variant_amount, txt2img_variant_seed]
+                                  txt2img_embeddings, txt2img_variant_amount, txt2img_variant_seed, txt2img_animation_steps, txt2img_animation_levels]
                 txt2img_outputs = [output_txt2img_gallery, output_txt2img_video, output_txt2img_seed,
                                    output_txt2img_params, output_txt2img_stats]
 

--- a/scripts/animation.py
+++ b/scripts/animation.py
@@ -1,0 +1,137 @@
+import code
+import torch
+import cv2
+import math
+import numpy as np
+# Note: in order for this to work, need the patched class KDiffusionSampler which includes new function set_sigma_start_end_indices 
+
+def int_log2(x):
+    return int(math.log2(x))
+        
+def animation_sample(prompt_start, prompt_end, num_animation_frames, steps, maybe_modelCS, func_sample, sampler, x, init_data, sampler_name, batch_size):
+    uc = maybe_modelCS.get_learned_conditioning([""])
+    MIN_SQUARE_DIFF_FACTOR = 0.5 # TODO: want this as a parameter? Increasing this can result in smoother animation.
+    DONT_AVERAGE_LAST_LEVEL = True # TODO: want it as parameter? should prevent some small artifacts. 
+    batch_uc = torch.cat([uc for i in range(batch_size)])
+    
+    c_start = maybe_modelCS.get_learned_conditioning(prompt_start)
+    c_end = maybe_modelCS.get_learned_conditioning(prompt_end)
+    
+    max_tree_height = int_log2(num_animation_frames)
+    if num_animation_frames != (1<<max_tree_height):
+        max_tree_height+=1
+        num_animation_frames = (1<<max_tree_height)
+        print(f"changing num animation frames to a power of 2: {num_animation_frames}")
+        
+    current_samples = x
+    previous_conditioning_ratios = [0]
+    levels_sizes = [(1 << i) for i in range(max_tree_height + 1)] # TODO: want those as parameters?
+    num_levels = len(levels_sizes)
+    if num_levels == 1: # For single picture
+        steps_per_level = [0]
+    else:
+        steps_per_level = list(range(0, steps, steps // num_levels))
+    
+    for current_level in range(num_levels):
+        print(f"animation: level {current_level+1}/{num_levels}")
+        print(f"current_samples.shape={current_samples.shape}")
+        current_level_size = levels_sizes[current_level]
+        
+        new_sample_inputs = []
+        new_sample_inputs_indices = []
+        new_sample_ratios = []
+        if current_level_size <= 2:
+            new_sample_inputs = [current_samples[0]] * current_level_size
+            new_sample_inputs_indices = [0] * current_level_size
+            new_sample_ratios = [1] * current_level_size
+            if current_level_size == 1:
+                conditioning_ratios = [0.5]
+            else:
+                conditioning_ratios = [0, 1]
+        else:
+            squared_diffs = torch.sqrt(
+                torch.sum(
+                    torch.square(
+                    torch.diff(current_samples, dim=0)
+                    ),
+                    list(range(1, len(current_samples.shape))))
+            ).cpu()
+            min_square_diff = torch.min(squared_diffs)
+            squared_diffs -= min_square_diff * MIN_SQUARE_DIFF_FACTOR # Try to ignore differences from random
+            squared_diffs_sums = torch.cat((torch.zeros(1), torch.cumsum(squared_diffs, dim=0)))
+            squared_diffs_sums = previous_conditioning_ratios[0] + squared_diffs_sums * ( (previous_conditioning_ratios[-1] - previous_conditioning_ratios[0]) / squared_diffs_sums[-1])
+            print(f"squared_diffs sums: {list(enumerate(squared_diffs_sums))}")
+            
+            conditioning_ratios = []
+            j = 0
+            max_j = len(previous_conditioning_ratios) - 1
+            for i in range(current_level_size):
+                wanted_ratio = i / (current_level_size - 1)
+                
+                while j <= max_j and wanted_ratio >= squared_diffs_sums[j]:
+                    j+=1
+                #print(f"i={i}, wanted_ratio={wanted_ratio}, j={j}")
+                if j <= 0:
+                    new_sample_inputs.append(current_samples[0])
+                    new_sample_ratios.append(1)
+                    conditioning_ratios.append(wanted_ratio)
+                elif j > max_j:
+                    j = max_j
+                    new_sample_inputs.append(current_samples[j])
+                    conditioning_ratios.append(wanted_ratio)
+                    new_sample_ratios.append(1)
+                else:
+                    j -= 1
+                    #print(f"i={i}, wanted_ratio={wanted_ratio}, j={j}, squared_diffs_sums[{j}]={squared_diffs_sums[j]}, squared_diffs_sums[{j+1}]={squared_diffs_sums[j+1]}")
+                    first_ratio = 1 - (wanted_ratio - squared_diffs_sums[j]) / (squared_diffs_sums[j+1] - squared_diffs_sums[j])
+                    new_sample_ratios.append(first_ratio)
+                    conditioning_ratio = previous_conditioning_ratios[j] * first_ratio + (1-first_ratio) * previous_conditioning_ratios[j+1]
+                    conditioning_ratios.append(conditioning_ratio)
+                    if current_level == num_levels - 1 and DONT_AVERAGE_LAST_LEVEL: # Don't average in the last level
+                        if first_ratio >= 0.5:
+                            new_sample = current_samples[j]
+                        else:
+                            new_sample = current_samples[j+1]
+                    else:
+                        new_sample = current_samples[j] * first_ratio + (1-first_ratio) * current_samples[j+1]
+                    new_sample_inputs.append(new_sample)
+                new_sample_inputs_indices.append(j)
+                
+            
+        conditioning_tensor = torch.cat([c_start * (1-ratio) + c_end * ratio for ratio in conditioning_ratios])
+            
+        print(f"new samples indices taken from: {new_sample_inputs_indices}")
+        print(f"conditioning_ratios: {conditioning_ratios}")
+        print(f"[(i, ratio, parent_sample_index, sample_ratio)] = {list(zip(range(current_level_size), conditioning_ratios, new_sample_inputs_indices, new_sample_ratios))}")
+        new_sample_inputs = torch.cat([sample[None] for sample in new_sample_inputs])
+        sigma_start = steps_per_level[current_level]
+        if current_level == num_levels - 1:
+            sigma_end = None
+        else:
+            sigma_end = steps_per_level[current_level + 1] + 1 # +1 to sigma_end because of a bug where it always skips the last sigma.
+        print(f"animation: level {current_level+1}/{num_levels}, sigma_start={sigma_start}, sigma_end={sigma_end}")
+        print(f"new_sample_inputs shape={new_sample_inputs.shape}, current_samples.shape = {current_samples.shape}")
+        sampler.set_sigma_start_end_indices(sigma_start, sigma_end)
+        for batch_offset in range(0, current_level_size, batch_size):
+            batch_results = func_sample(init_data=init_data, x=new_sample_inputs[batch_offset:batch_offset+batch_size], conditioning=conditioning_tensor[batch_offset:batch_offset+batch_size], unconditional_conditioning=batch_uc[:min(batch_size, current_level_size-batch_offset)], sampler_name=sampler_name)
+            if batch_offset == 0:
+                current_samples = batch_results
+            else:
+                current_samples = torch.cat((current_samples, batch_results))
+        previous_conditioning_ratios = conditioning_ratios
+    
+    return current_samples
+
+def save_animation(output_frames, output_path, codec=None, fps = None, animation_duration = 5): # TODO: fps / frames interpolation.
+    if fps is None:
+        fps = max(1, len(output_frames) // animation_duration) # At least 1 FPS.
+    if output_path.endswith("avi") and codec is None:
+        codec = "XVID"
+    elif output_path.endswith("mp4") and codec is None:
+        codec = "avc1" # Need to download binaries from cisco for this to work.
+    print(f"saving animation to '{output_path}', codec={codec}, fps={fps}, number of frames: {len(output_frames)}")
+    out = cv2.VideoWriter(output_path,cv2.VideoWriter_fourcc(*codec), fps, (output_frames[0].width, output_frames[0].height))
+    for frame in output_frames:
+        cv_im = np.array(frame)
+        out.write(cv_im[:,:,::-1])
+    out.release()

--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -53,6 +53,8 @@ opt = parser.parse_args()
 #else:
 #    os.environ["CUDA_VISIBLE_DEVICES"] = str(opt.gpu)
 
+import traceback
+
 import gradio as gr
 import k_diffusion as K
 import math
@@ -83,6 +85,8 @@ from torch import autocast
 from ldm.models.diffusion.ddim import DDIMSampler
 from ldm.models.diffusion.plms import PLMSSampler
 from ldm.util import instantiate_from_config
+
+from scripts.animation import animation_sample, save_animation
 
 try:
     # this silences the annoying "Some weights of the model checkpoint were not used when initializing..." message at start.
@@ -256,17 +260,32 @@ class CFGDenoiser(nn.Module):
         uncond, cond = self.inner_model(x_in, sigma_in, cond=cond_in).chunk(2)
         return uncond + (cond - uncond) * cond_scale
 
-
 class KDiffusionSampler:
     def __init__(self, m, sampler):
         self.model = m
         self.model_wrap = K.external.CompVisDenoiser(m)
         self.schedule = sampler
+        self.sigma_start_index = 0
+        self.sigma_end_index = None
+        
+    def set_sigma_start_end_indices(self, sigma_start_index, sigma_end_index): # Note: this is important for animation.
+        self.sigma_start_index = sigma_start_index
+        self.sigma_end_index = sigma_end_index
+        
     def get_sampler_name(self):
         return self.schedule
+        
     def sample(self, S, conditioning, batch_size, shape, verbose, unconditional_guidance_scale, unconditional_conditioning, eta, x_T):
         sigmas = self.model_wrap.get_sigmas(S)
-        x = x_T * sigmas[0]
+        if self.sigma_start_index == 0:
+            x = x_T * sigmas[0]
+        else:
+            x = x_T
+            
+        if self.sigma_end_index is not None:
+            sigmas = sigmas[self.sigma_start_index:self.sigma_end_index]
+        else:
+            sigmas = sigmas[self.sigma_start_index:]
         model_wrap_cfg = CFGDenoiser(self.model_wrap)
 
         samples_ddim = K.sampling.__dict__[f'sample_{self.schedule}'](model_wrap_cfg, x, sigmas, extra_args={'cond': conditioning, 'uncond': unconditional_conditioning, 'cond_scale': unconditional_guidance_scale}, disable=False)
@@ -693,7 +712,7 @@ def get_next_sequence_number(path, prefix=''):
     """
     result = -1
     for p in Path(path).iterdir():
-        if p.name.endswith(('.png', '.jpg')) and p.name.startswith(prefix):
+        if (p.name.endswith(('.png', '.jpg')) and p.name.startswith(prefix)) or p.is_dir():
             tmp = p.name[len(prefix):]
             try:
                 result = max(int(tmp.split('-')[0]), result)
@@ -776,19 +795,19 @@ def oxlamon_matrix(prompt, seed, n_iter, batch_size):
     return all_seeds, n_iter, prompt_matrix_parts, all_prompts, needrows
 
 
-
 def process_images(
         outpath, func_init, func_sample, prompt, seed, sampler_name, skip_grid, skip_save, batch_size,
         n_iter, steps, cfg_scale, width, height, prompt_matrix, use_GFPGAN, use_RealESRGAN, realesrgan_model_name,
         fp, ddim_eta=0.0, do_not_save_grid=False, normalize_prompt_weights=True, init_img=None, init_mask=None,
         keep_mask=False, mask_blur_strength=3, denoising_strength=0.75, resize_mode=None, uses_loopback=False,
         uses_random_seed_loopback=False, sort_samples=True, write_info_files=True, write_sample_info_to_log_file=False, jpg_sample=False,
-        variant_amount=0.0, variant_seed=None,imgProcessorTask=False, job_info: JobInfo = None):
+        variant_amount=0.0, variant_seed=None,imgProcessorTask=False, job_info: JobInfo = None, sampler=None, output_video=False):
     """this is the main loop that both txt2img and img2img use; it calls func_init once inside all the scopes and func_sample once per batch"""
     prompt = prompt or ''
     torch_gc()
     # start time after garbage collection (or before?)
     start_time = time.time()
+    output_video_path = None
 
     mem_mon = MemUsageMonitor('MemMon')
     mem_mon.start()
@@ -804,6 +823,17 @@ def process_images(
     if not ("|" in prompt) and prompt.startswith("@"):
         prompt = prompt[1:]
 
+    animation_prompt = False
+    num_animation_frames = 1
+    if prompt.find("~") != -1:
+        animation_prompt = True
+        prompt_start = prompt[:prompt.find("~")]
+        prompt_end = prompt[prompt.find("~")+1:]
+        num_animation_frames = n_iter
+        n_iter = 1
+        VIDEO_FORMAT = "mp4" # TODO: make parameter.
+        print(f"creating animation between '{prompt_start}' => '{prompt_end}', frames: {num_animation_frames}")
+        
     comments = []
 
     prompt_matrix_parts = []
@@ -831,6 +861,9 @@ def process_images(
             all_seeds = len(all_prompts) * [seed]
 
         print(f"Prompt matrix will create {len(all_prompts)} images using a total of {n_iter} batches.")
+    elif animation_prompt:
+        all_prompts = [f"{prompt_start}~{prompt_end}" for i in range(num_animation_frames)]
+        all_seeds = [seed] * num_animation_frames        
     else:
 
         if not opt.no_verify_input:
@@ -880,6 +913,11 @@ def process_images(
             seeds = all_seeds[n * batch_size:(n + 1) * batch_size]
             current_seeds = original_seeds[n * batch_size:(n + 1) * batch_size]
 
+            if animation_prompt:
+                prompts = all_prompts
+                seeds = all_seeds
+                current_seeds = all_seeds
+            
             if job_info:
                 job_info.job_status = f"Processing Iteration {n+1}/{n_iter}. Batch size {batch_size}"
                 for idx,(p,s) in enumerate(zip(prompts,seeds)):
@@ -915,7 +953,10 @@ def process_images(
             cur_variant_amount = variant_amount 
             if variant_amount == 0.0:
                 # we manually generate all input noises because each one should have a specific seed
-                x = create_random_tensors(shape, seeds=seeds)
+                if animation_prompt:
+                    x = create_random_tensors(shape, seeds=seeds[:1])
+                else:
+                    x = create_random_tensors(shape, seeds=seeds)
             else: # we are making variants
                 # using variant_seed as sneaky toggle,
                 # when not None or '' use the variant_seed
@@ -935,15 +976,35 @@ def process_images(
                 # finally, slerp base_x noise to target_x noise for creating a variant
                 x = slerp(device, max(0.0, min(1.0, cur_variant_amount)), base_x, target_x)
 
-            samples_ddim = func_sample(init_data=init_data, x=x, conditioning=c, unconditional_conditioning=uc, sampler_name=sampler_name)
+            if animation_prompt:
+                maybe_modelCS = (model if not opt.optimized else modelCS)
+                samples_ddim = animation_sample(prompt_start=prompt_start, prompt_end=prompt_end, num_animation_frames=num_animation_frames, steps=steps, func_sample=func_sample, sampler=sampler, init_data=init_data, x=x, sampler_name=sampler_name, batch_size = batch_size, maybe_modelCS=maybe_modelCS)
+                # Sometimes more frames are generated:
+                if num_animation_frames != len(samples_ddim):
+                    num_animation_frames = len(samples_ddim)
+                    prompts = [f"{prompt_start}~{prompt_end}" for i in range(num_animation_frames)]
+                    seeds = [seed] * num_animation_frames
+                    current_seeds = [seed] * num_animation_frames
+            else:
+                samples_ddim = func_sample(init_data=init_data, x=x, conditioning=c, unconditional_conditioning=uc, sampler_name=sampler_name)
 
             if opt.optimized:
                 modelFS.to(device)
 
 
-
-            x_samples_ddim = (model if not opt.optimized else modelFS).decode_first_stage(samples_ddim)
-            x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
+            if animation_prompt:
+                # Can't decode too many animation frames in parallel.
+                x_samples_ddim = torch.cat([
+                torch.clamp(
+                ((model if not opt.optimized else modelFS).decode_first_stage(samples_ddim[i][None]) + 1.0)/2.0
+                , min=0.0, max=1.0).cpu()
+                for i in range(samples_ddim.shape[0])
+                ])
+            else:
+                x_samples_ddim = (model if not opt.optimized else modelFS).decode_first_stage(samples_ddim)
+                x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)
+                
+            base_filename = None
             for i, x_sample in enumerate(x_samples_ddim):
                 sanitized_prompt = prompts[i].replace(' ', '_').translate({ord(x): '' for x in invalid_filename_chars})
                 if variant_seed != None and variant_seed != '':
@@ -965,6 +1026,13 @@ def process_images(
                     sanitized_prompt = sanitized_prompt
                     filename = f"{base_count:05}-{steps}_{sampler_name}_{seed_used}_{cur_variant_amount:.2f}_{sanitized_prompt}"[:128] #same as before
 
+                if animation_prompt:
+                    if base_filename is None:
+                        base_filename = f"{base_count:05}-{steps}_{sampler_name}_{seed_used}"
+                        base_path = os.path.join(sample_path_i, base_filename)
+                        os.makedirs(base_path, exist_ok=True)
+                    filename = os.path.join(base_filename, f"{i}")
+                    
                 x_sample = 255. * rearrange(x_sample.cpu().numpy(), 'c h w -> h w c')
                 x_sample = x_sample.astype(np.uint8)
                 image = Image.fromarray(x_sample)
@@ -1032,8 +1100,14 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
                 modelFS.to("cpu")
                 while(torch.cuda.memory_allocated()/1e6 >= mem):
                     time.sleep(1)
-
-        if (prompt_matrix or not skip_grid) and not do_not_save_grid:
+                    
+        # END of for n iter
+        # -----------------
+        if animation_prompt:
+            output_video_path = os.path.join(base_path, "animation." + VIDEO_FORMAT)
+            save_animation(output_images,output_video_path) # TODO: codec parameters.
+            
+        if (prompt_matrix or not skip_grid) and not do_not_save_grid and not animation_prompt:
             grid = None
             if prompt_matrix:
                 if simple_templating:
@@ -1083,7 +1157,8 @@ Peak memory usage: { -(mem_max_used // -1_048_576) } MiB / { -(mem_total // -1_0
     #mem_mon.stop()
     #del mem_mon
     torch_gc()
-
+    if output_video:
+        return output_images, output_video_path, seed, info, stats
     return output_images, seed, info, stats
 
 
@@ -1139,7 +1214,7 @@ def txt2img(prompt: str, ddim_steps: int, sampler_name: str, toggles: List[int],
         return samples_ddim
 
     try:
-        output_images, seed, info, stats = process_images(
+        output_images, video_output, seed, info, stats = process_images(
             outpath=outpath,
             func_init=init,
             func_sample=sample,
@@ -1168,16 +1243,22 @@ def txt2img(prompt: str, ddim_steps: int, sampler_name: str, toggles: List[int],
             variant_amount=variant_amount,
             variant_seed=variant_seed,
             job_info=job_info,
+            sampler=sampler,  # sampler is needed for animation.
+            output_video=True, # return video output parameter.
         )
 
         del sampler
-
-        return output_images, seed, info, stats
+        
+        return output_images, video_output, seed, info, stats
+        
     except RuntimeError as e:
         err = e
-        err_msg = f'CRASHED:<br><textarea rows="5" style="color:white;background: black;width: -webkit-fill-available;font-family: monospace;font-size: small;font-weight: bold;">{str(e)}</textarea><br><br>Please wait while the program restarts.'
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        err_str = '\n'.join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+        err_msg = f'CRASHED:<br><textarea rows="5" style="color:white;background: black;width: -webkit-fill-available;font-family: monospace;font-size: small;font-weight: bold;">{err_str}</textarea><br><br>Please wait while the program restarts.'
         stats = err_msg
-        return [], seed, 'err', stats
+        print(f"got exception:\n {err_str}")
+        return [], None, seed, 'err', stats
     finally:
         if err:
             crash(err, '!!Runtime error (txt2img)!!')


### PR DESCRIPTION
Implemented support for creating animation between two prompts using tilde ~ in txt2img.
Most animation logic is in animate.py, there's important addition to KDiffusionSampler class (animation only works with those). Rest of the changes are additional tab for viewing the video in txt2img in gradio, and small changes in process_images and txt2img to pass the parameters.

(It's not naïve animation generation, like img2img loopback methods, there's logic to try and get as smooth animation as possible instead of jumpy animation with noise and things randomly popping in and out of existence between frames)

Requires getting openh264 codec in windows to encode the mp4 video (but the frames are generated either way).