### PR TITLE
support negative prompts separated by ###

### DIFF
--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -804,6 +804,12 @@ def process_images(
     if not ("|" in prompt) and prompt.startswith("@"):
         prompt = prompt[1:]
 
+    negprompt = ''
+    if '###' in prompt:
+        prompt, negprompt = prompt.split('###', 1)
+        prompt = prompt.strip()
+        negprompt = negprompt.strip()
+
     comments = []
 
     prompt_matrix_parts = []
@@ -887,7 +893,7 @@ def process_images(
 
             if opt.optimized:
                 modelCS.to(device)
-            uc = (model if not opt.optimized else modelCS).get_learned_conditioning(len(prompts) * [""])
+            uc = (model if not opt.optimized else modelCS).get_learned_conditioning(len(prompts) * [negprompt])
             if isinstance(prompts, tuple):
                 prompts = list(prompts)
 


### PR DESCRIPTION
e.g. "shopping mall ### people" will try to generate an image of a mall without people in it. This is a powerful way to finetune images to avoid certain things in ways that are difficult to achieve with prompt weighting alone.

`###` was chosen as a separator to easy to type and be very unlikely to be accidentally included in a prompt.

prompt: `a mall in america, 35mm film`:
![](https://cdn.discordapp.com/attachments/1017861336232894565/1018591149755220099/a_mall_in_america_35mm_film_589621626.png)


prompt: `a mall in america, 35mm film ### people, crowd`
![](https://cdn.discordapp.com/attachments/1017861336232894565/1018591254130466936/a_mall_in_america_35mm_film_589621626.png)

see also #999