### PR TITLE
Docker validate model files if not a symlink in case user has VALIDATE_MODELS=false set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,7 +93,7 @@ validateDownloadModel() {
 echo "Validating model files..."
 for models in "${MODEL_FILES[@]}"; do
     model=($models)
-    if [[ ! -e ${model[1]}/${model[0]} || -z $VALIDATE_MODELS || $VALIDATE_MODELS == "true" ]]; then
+    if [[ ! -e ${model[1]}/${model[0]} || ! -L ${model[1]}/${model[0]} || -z $VALIDATE_MODELS || $VALIDATE_MODELS == "true" ]]; then
         validateDownloadModel ${model[0]} ${model[1]} ${model[2]} ${model[3]}
     fi
 done


### PR DESCRIPTION
This is to ensure consistency in structure across users, if they had previously set VALIDATE_MODELS=false they would possibly not be using symlinks to model_cache 