### PR TITLE
Multiple Improvements to the txt2vid tab and other misc stuff.

### DIFF
--- a/configs/webui/webui_streamlit.yaml
+++ b/configs/webui/webui_streamlit.yaml
@@ -73,7 +73,7 @@ txt2vid:
     separate_prompts: False
     normalize_prompt_weights: True
     save_individual_images: True
-    save_grid: False
+    save_video: True
     group_by_prompt: True
     write_info_files: True
     do_loop: False

--- a/configs/webui/webui_streamlit.yaml
+++ b/configs/webui/webui_streamlit.yaml
@@ -44,6 +44,8 @@ txt2img:
     sampling_steps: 30
     default_sampler: "k_euler"
     separate_prompts: False
+    update_preview: True
+    update_preview_frequency: 5
     normalize_prompt_weights: True
     save_individual_images: True
     save_grid: True
@@ -71,6 +73,9 @@ txt2vid:
     default_sampler: "k_euler"
     scheduler_name: "klms"
     separate_prompts: False
+    update_preview: True
+    update_preview_frequency: 5
+    dynamic_preview_frequency: True
     normalize_prompt_weights: True
     save_individual_images: True
     save_video: True
@@ -85,7 +90,7 @@ txt2vid:
     variant_seed: ""
     beta_start: 0.00085
     beta_end: 0.012
-    beta_scheduler_type: "scaled_linear"
+    beta_scheduler_type: "linear"
     max_frames: 1000
     
 img2img:
@@ -125,6 +130,8 @@ img2img:
   loopback: True
   random_seed_loopback: True
   separate_prompts: False
+  update_preview: True
+  update_preview_frequency: 5
   normalize_prompt_weights: True
   save_individual_images: True
   save_grid: True

--- a/scripts/Settings.py
+++ b/scripts/Settings.py
@@ -1,0 +1,6 @@
+import streamlit as st
+from webui_streamlit import defaults
+
+# The global settings section will be moved to the Settings page.
+#with st.expander("Global Settings:"):
+st.write("Global Settings:")


### PR DESCRIPTION
# Description
- Added the Update Image Preview option to be part of the current tab options under Preview Settings.
- Added Dynamic Preview Frequency option for the txt2vid tab which tries to find the lowest value for update_preview_frequency at which we can update the preview image during generation while at the same time minimizing the impact it has in performance.
- Added option to save a video file to the outputs/txt2vid-samples folder after the generation is complete similar to how the save_grid option works on other tabs.
- Added a video preview which shows a video on the txt2vid tab when the generation is completed.
- Formatted some lines of code to make it use less space and fit on a single screen.
- Added a script called Settings.py to the script folder in which Settings for the Setting page will be placed. Empty for now.
- Renamed the save_grid option for txt2vid on the config file to be `save_video`, this will be used to determine if the user wants to save a video at the end of the generation or not, similar to the save_grid that is used on txt2img and img2img but for video.

# Checklist:
- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas