### PR TITLE
Osi1880vr expected scalar type Half but found Float patch

### DIFF
--- a/scripts/webui_streamlit.py
+++ b/scripts/webui_streamlit.py
@@ -1986,7 +1986,7 @@ def txt2vid(
 			                weights_path,
 			                use_local_file=True,
 			                use_auth_token=True,
-			                torch_dtype=torch.float16,
+			                #torch_dtype=torch.float16,
 			                #revision="fp16"
 			        )
 	


### PR DESCRIPTION
# Description

This should fix an error when running txt2img. the error sounds like this 
RuntimeError: expected scalar type Half but found Float

Im new to the process, it shows me 7 commits but in the end only changes 1 line, thats the plan. I hope it works.
If not, punish me and educate how to do this much more elegant :D

Please include:
* relevant motivation
* a summary of the change
* which issue is fixed.
* any additional dependencies that are required for this change.

Closes: # #1047 (I hope) It is working on my box with this :P

# Checklist:

- [x ] I have changed the base branch to `dev`
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation