### PR TITLE
Job manager typo fix

### DIFF
--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -213,7 +213,7 @@ class JobManager:
 
         # If we didn't already get a token then queue up for one
         if job_info.job_token is None:
-            job_info.token = self._get_job_token(block=True)
+            job_info.job_token = self._get_job_token(block=True)
 
         # Buttons don't seem to update unless value is set on them as well...
         return {output_dummy_obj: triggerChangeEvent(),


### PR DESCRIPTION
# Description

Please include:
Typo fix in job manager which could cause max-jobs=1 to stop responding

Closes: #858 #1041

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation