### PR TITLE
JobManager: Buttons skip queue

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -126,17 +126,22 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                         inputs=txt2img_inputs,
                         outputs=txt2img_outputs
                     )
+                    use_queue = False
+                else:
+                    use_queue = True
 
                 txt2img_btn.click(
                     txt2img_func,
                     txt2img_inputs,
                     txt2img_outputs,
-                    api_name='txt2img'
+                    api_name='txt2img',
+                    queue=use_queue
                 )
                 txt2img_prompt.submit(
                     txt2img_func,
                     txt2img_inputs,
-                    txt2img_outputs
+                    txt2img_outputs,
+                    queue=use_queue
                 )
 
                 txt2img_width.change(fn=uifn.update_dimensions_info, inputs=[txt2img_width, txt2img_height], outputs=txt2img_dimensions_info_text_box)
@@ -357,13 +362,16 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                         inputs=img2img_inputs,
                         outputs=img2img_outputs,
                     )
+                    use_queue = False
+                else:
+                    use_queue = True
 
                 img2img_btn_mask.click(
                     img2img_func,
                     img2img_inputs,
                     img2img_outputs,
-                    api_name="img2img"
-
+                    api_name="img2img",
+                    queue=use_queue
                 )
 
                 def img2img_submit_params():

--- a/frontend/job_manager.py
+++ b/frontend/job_manager.py
@@ -310,7 +310,8 @@ class JobManager:
         update_gallery_obj.change(
             partial(self._update_gallery_event, func_key),
             [self._session_key],
-            [gallery_comp]
+            [gallery_comp],
+            queue=False
         )
 
         if refresh_btn:
@@ -318,7 +319,8 @@ class JobManager:
             refresh_btn.click(
                 partial(self._refresh_func, func_key),
                 [self._session_key],
-                [update_gallery_obj, status_text]
+                [update_gallery_obj, status_text],
+                queue=False
             )
 
         if stop_btn:
@@ -326,7 +328,8 @@ class JobManager:
             stop_btn.click(
                 partial(self._stop_wrapped_func, func_key),
                 [self._session_key],
-                [status_text]
+                [status_text],
+                queue=False
             )
 
         # (ab)use gr.JSON to forward events.
@@ -352,21 +355,24 @@ class JobManager:
         post_call_dummyobj.change(
             partial(self._post_call_func, func_key, update_gallery_obj, *job_ui_params),
             [self._session_key],
-            [update_gallery_obj] + job_ui_outputs
+            [update_gallery_obj] + job_ui_outputs,
+            queue=False
         )
 
         call_dummyobj = gr.JSON(visible=False, elem_id="JobManagerDummyObject_runCall")
         call_dummyobj.change(
             partial(self._call_func, func_key),
             [self._session_key],
-            outputs + [post_call_dummyobj]
+            outputs + [post_call_dummyobj],
+            queue=False
         )
 
         pre_call_dummyobj = gr.JSON(visible=False, elem_id="JobManagerDummyObject_preCall")
         pre_call_dummyobj.change(
             partial(self._pre_call_func, func_key, call_dummyobj, *job_ui_params),
             [self._session_key],
-            [call_dummyobj] + job_ui_outputs
+            [call_dummyobj] + job_ui_outputs,
+            queue=False
         )
 
         # Now replace the original function with one that creates a JobInfo and triggers the dummy obj


### PR DESCRIPTION
Have JobManager buttons skip Gradio's queue, since otherwise they aren't sending JobManager button presses.

Versions of gradio past 3.1.6  (and perhaps even 3.1.6 for some people?) have issues with JobManager not responding to button presses because Gradio won't tell JobManager about them until the queue is empty.

This commit just tells all of the job-manager related buttons to skip the queue. This prevents Gradio from queueing up the button presses.

Closes: # (issue)

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation