### PR TITLE
Prompt user if they wish to restore changes

### DIFF
--- a/update_to_latest.cmd
+++ b/update_to_latest.cmd
@@ -36,7 +36,18 @@ IF "%v_conda_path%"=="" (
 echo Stashing local changes and pulling latest update...
 call git stash
 call git pull
-echo If you want to restore changes you made before updating, run "git stash pop".
+set /P restore="Do you want to restore changes you made before updating? (Y/N): "
+IF "%restore%" == "N" (
+  echo Removing changes please wait...
+  call git stash drop
+  echo Changes removed, press any key to continue...
+  pause >nul
+) ELSE IF "%restore%" == "Y" (
+  echo Restoring changes, please wait...
+  call git stash pop --quiet
+  echo Changes restored, press any key to continue...
+  pause >nul
+)
 call "%v_conda_path%\Scripts\activate.bat"
 
 for /f "delims=" %%a in ('git log -1 --format^="%%H" -- environment.yaml')  DO set v_cur_hash=%%a


### PR DESCRIPTION
# Description

An attempt to make it easier for the end user to restore any custom changes without opening a second prompt window.

- After stashing any changes and pulling updates, ask user if they wish to pop changes
- If user declines the restore, drop the stash to prevent the case of an ever growing stash pile

Any feedback or changes are welcome! I'm not really up to date on efficient batch scripting.
Currently git stash pop has the --quiet flag, but if having the full output is preferred, that is okay. 

# Checklist:

- [X] I have changed the base branch to `dev`
- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation