### PR TITLE
Fixed decimal prompt weights without leading digit

### DIFF
--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -1519,7 +1519,7 @@ prompt_parser = re.compile("""
     (?:             # non-capture group
     :+              # match one or more ':' characters
     (?P<weight>     # capture group for 'weight'
-    -?\d+(?:\.\d+)? # match positive or negative integer or decimal number
+    -?\d*\.{0,1}\d+ # match positive or negative integer or decimal number
     )?              # end weight capture group, make optional
     \s*             # strip spaces after weight
     |               # OR


### PR DESCRIPTION
The regex was not accounting properly for prompt weights that didn't begin with a leading number such as .5 or .1 and was instead splitting those off into their own prompt which got everything all screwed up.

For example, the prompt string of "Fruit:1 grapes:-.5" should parse as [('Fruit', 1.0), ('grapes', -.5)]
but was being incorrectly parsed as
[('Fruit', 1.0), ('grapes', 1.0), ('-.5', 1.0)]

This fixes that by making the regex properly catch decimals.

# Description

Please include:
* relevant motivation
* a summary of the change
* which issue is fixed.
* any additional dependencies that are required for this change.

Closes: # (issue)

# Checklist:

- [ ] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation