### PR TITLE
Minor fix: Fix error when attempting to restore a mask, but no mask is given

### DIFF
--- a/scripts/img2img.py
+++ b/scripts/img2img.py
@@ -291,7 +291,7 @@ def img2img(prompt: str = '', init_info: any = None, init_info_mask: any = None,
 					correction_target,
 					channel_axis=2
 				    ), cv2.COLOR_LAB2RGB).astype("uint8"))
-				if mask_restore is True:
+				if mask_restore is True and init_mask is not None:
 					color_mask = init_mask.filter(ImageFilter.GaussianBlur(mask_blur_strength))
 					color_mask = color_mask.convert('L')
 					source_image = input_image.convert('RGB')


### PR DESCRIPTION
# Description

If "only modify regenerated parts of image" is checked, but no mask is given, an invalid access exception is raised due to the null mask. This just adds a guard clause to ensure we have a mask first.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation