### PR TITLE
When running a batch with preview turned on, produce a grid of previe…

### DIFF
--- a/scripts/sd_utils.py
+++ b/scripts/sd_utils.py
@@ -809,7 +809,11 @@ def generation_callback(img, i=0):
 
         x_samples_ddim = torch.clamp((x_samples_ddim + 1.0) / 2.0, min=0.0, max=1.0)  
 
-        pil_image = transforms.ToPILImage()(x_samples_ddim.squeeze_(0)) 			
+        if x_samples_ddim.ndimension() == 4:
+            pil_images = [transforms.ToPILImage()(x.squeeze_(0)) for x in x_samples_ddim]
+            pil_image = image_grid(pil_images, 1)
+        else:
+            pil_image = transforms.ToPILImage()(x_samples_ddim.squeeze_(0))
 
         # update image on the UI so we can see the progress
         st.session_state["preview_image"].image(pil_image) 	


### PR DESCRIPTION
# Description

Errors would be thrown if preview was on in batch mode due to the output tensor having an extra dimension. This fixes that and produces an image grid of the preview images. The final image displayed is still just a single image; as an improvement, it might be appropriate to display it as a grid of the final imges instead.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation