### PR TITLE
Fix errors on early termination

### DIFF
--- a/scripts/sd_utils.py
+++ b/scripts/sd_utils.py
@@ -787,6 +787,8 @@ def ModelLoader(models,load=False,unload=False,imgproc_realesrgan_model_name='Re
 #
 @retry(tries=5)
 def generation_callback(img, i=0):
+    if "update_preview_frequency" not in st.session_state:
+        return
 
     try:
         if i == 0:	


### PR DESCRIPTION
# Description

When early terminating, generation_callback gets invoked but st.session_state is empty, resulting in key errors.

When this happens, we can just return early (since we have indicated we don't care about further preview or progress updates!)

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation