### PR TITLE
Better handling for final displays of images

### DIFF
--- a/scripts/sd_utils.py
+++ b/scripts/sd_utils.py
@@ -796,7 +796,7 @@ def generation_callback(img, i=0):
     except TypeError:
         pass
 
-    if i % int(st.session_state.update_preview_frequency) == 0 and st.session_state.update_preview:
+    if i % int(st.session_state.update_preview_frequency) == 0 and st.session_state.update_preview and i > 0:
         #print (img)
         #print (type(img))
         # The following lines will convert the tensor we got on img to an actual image we can render on the UI.
@@ -1436,6 +1436,8 @@ def process_images(
                 image = Image.fromarray(x_sample)
                 original_sample = x_sample
                 original_filename = filename
+
+                st.session_state["preview_image"].image(image)
 
                 if use_GFPGAN and st.session_state["GFPGAN"] is not None and not use_RealESRGAN:
                     st.session_state["progress_bar_text"].text("Running GFPGAN on image %d of %d..." % (i+1, len(x_samples_ddim)))


### PR DESCRIPTION
This is a collection of several changes to enhance image display:

* When using GFPGAN or RealESRGAN, only the final output will be displayed.
* In batch>1 mode, each final image will be collected into an image grid for display
* The image is constrained to a reasonable size to ensure that batch grids of RealESRGAN'd images don't end up spitting out a massive image that the browser then has to handle.
* Additionally, the progress bar indicator is updated as each image is post-processed.

This was done to address several issues:

1. When using post-processing, the processed image only flashed for a brief moment, then the final original image was re-displayed
2. In batch mode, each image in the batch was briefly flashed, with the last image being the one finally displayed
3. Large image grids could be excessively burdensome on the browser

Closes: # (issue)

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation