### PR TITLE
Send the image grid to the front end if generated for a prompt matrix

### DIFF
--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -1313,6 +1313,8 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
                 grid_count = get_next_sequence_number(outpath, 'grid-')
                 grid_file = f"grid-{grid_count:05}-{seed}_{prompts[i].replace(' ', '_').translate({ord(x): '' for x in invalid_filename_chars})[:128]}.{grid_ext}"
                 grid.save(os.path.join(outpath, grid_file), grid_format, quality=grid_quality, lossless=grid_lossless, optimize=True)
+                if prompt_matrix:
+                    output_images.append(grid)
 
         toc = time.time()
 


### PR DESCRIPTION
# Description

Made it so that the image grid is sent to the front end when it is generated for a prompt matrix.
Lets the user review the results without needing to dive into the output files manually. Very handy if the webui is being used via a separate machine.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation