### PR TITLE
Small tweaks to entrypoint.sh to allow for non-interactive running

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ cd $SCRIPT_DIR
 export PYTHONPATH=$SCRIPT_DIR
 
 MODEL_DIR="${SCRIPT_DIR}/model_cache"
+mkdir -p $MODEL_DIR
 # Array of model files to pre-download
 # local filename
 # local path in container (no trailing slash)
@@ -49,7 +50,7 @@ fi
 # Clear artifacts from conda after create/update
 # @see https://docs.conda.io/projects/conda/en/latest/commands/clean.html
 if (( $ENV_UPDATED > 0 )); then
-    conda clean --all
+    yes | conda clean --all
     echo -n $ENV_MODIFIED > $ENV_MODIFED_FILE
 fi
 


### PR DESCRIPTION
# Description

Please include:
* relevant motivation
  * Trying to run the docker image automatically (perhaps on Amazon ECR) and it requires these steps
* a summary of the change
  * Create the MODEL_DIR at the top of the script. This seems like an omission, I was not able to complete checkpoint download without this.
  * Pipe 'yes' to the conda clean command, so that interactive prompts are agreed to and no interaction is needed 
* which issue is fixed.
  * N/A
* any additional dependencies that are required for this change.
  * N/A

# Checklist:

- [ x ] I have changed the base branch to `dev`
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation