### PR TITLE
feat: move scale multiplication in attention.py

### DIFF
--- a/ldm/modules/attention.py
+++ b/ldm/modules/attention.py
@@ -236,7 +236,7 @@ class CrossAttention(nn.Module):
         slice_size = q.shape[1] // steps if (q.shape[1] % steps) == 0 else q.shape[1]  
         for i in range(0, q.shape[1], slice_size):
             end = min(q.shape[1], i + slice_size)
-            s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k) * self.scale
+            s1 = einsum('b i d, b j d -> b i j', q[:, i:end], k)# * self.scale
             s2 = s1.softmax(dim=-1, dtype=r1.dtype)
             del s1
             r1[:, i:end] = einsum('b i j, b j d -> b i d', s2, v)
@@ -249,7 +249,7 @@ class CrossAttention(nn.Module):
         q = self.to_q(x)
         context = default(context, x)
         del x
-        k = self.to_k(context)
+        k = self.to_k(context) * self.scale
         v = self.to_v(context)
         del context
 


### PR DESCRIPTION
# Description

Move the scale multiplication out of the for loop to improve inference speed. Some standard tests:

| Settings   | Batch Size | Dev                                           | Pull Request                                  |
|------------|------------|-----------------------------------------------|-----------------------------------------------|
| Euler/20   | 10         | (5.51s per image) Peak memory usage: 9657 MiB | (5.59s per image) Peak memory usage: 9600 MiB |
| Euler_a/35 | 10         | (9.45s per image) Peak memory usage: 9577 MiB | (8.51s per image) Peak memory usage: 9646 MiB |
| LMS/50     | 15         | (12.6s per image) Peak memory usage: 8987 MiB | (11.5s per image) Peak memory usage: 8998 MiB |

The change is mainly beneficial to higher batch sizes (and I imagine higher resolutions). The idea for this was mentioned on SD Discord, wasn't able to trace down the original author, only know that they have numbers in their username. 