### PR TITLE
Add periodic checkpointing and sample extraction to the v2 trainer

### DIFF
--- a/scripts/pipelines/stable_diffusion/no_check.py
+++ b/scripts/pipelines/stable_diffusion/no_check.py
@@ -1,0 +1,11 @@
+from diffusers import ModelMixin
+import torch
+
+class NoCheck(ModelMixin):
+    """Can be used in place of safety checker. Use responsibly and at your own risk."""
+    def __init__(self):
+        super().__init__()
+        self.register_parameter(name='asdf', param=torch.nn.Parameter(torch.randn(3)))
+
+    def forward(self, images=None, **kwargs):
+        return images, [False]


### PR DESCRIPTION
# Description

The v2 trainer seems to be faster and more efficient than the mainline trainer, yay! But it's missing the ability to checkpoint periodically, and to output sample images during training. This PR adds those features.

Several CLI flags are added:

* `--checkpoint_frequency` (default 500) - every N steps, write a checkpoint and image sample(s)
* `--sample_batch_size` (default 1) - the number of images to produce per sample batch
* `--random_sample_batches` (default 1) - the number of randomly-seeded images to produce per sample batch
* `--stable_sample_batches` (default 1) - the number of fixed-seed images to produce per sample batch
* `--custom_templates` (default None) - A comma-delimited list of custom template to use for sample prompts, using {} as a placeholder for the concept. (ie, `a dynamic photo of a {}`)

A noop model was added for sample generation, to help save on VRAM during training. Due to how diffusers reflects on module names, it needed to be a couple levels down in a subdirectory.

Additionally, images from the training directory are now filtered to .jpg/jpeg/png, and the final embeddings are saved in the output base path rather than in the training data path.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation