### PR TITLE
Fixed webui.cmd crash when having () in path. #1276

### DIFF
--- a/webui.cmd
+++ b/webui.cmd
@@ -82,7 +82,7 @@ call "%v_conda_path%\Scripts\activate.bat" "%v_conda_env_name%"
 :PROMPT
 set SETUPTOOLS_USE_DISTUTILS=stdlib
 IF EXIST "models\ldm\stable-diffusion-v1\model.ckpt" (
-  set PYTHONPATH=%~dp0
+  set "PYTHONPATH=%~dp0"
   python scripts\relauncher.py
 ) ELSE (
   echo Your model file does not exist! Place it in 'models\ldm\stable-diffusion-v1' with the name 'model.ckpt'.


### PR DESCRIPTION
# Description
Fixed webui.cmd crash when having () in path.

Closes: # (issue)
#1276