### PR TITLE
Fix broken output info in img2img to highlight parameters 

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -247,7 +247,9 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
 
                                 gr.Markdown("Warning: This will clear your current image and mask settings!")
                             with gr.TabItem("Output info", id="img2img_output_info_tab"):
-                                output_img2img_params = gr.Textbox(label="Generation parameters")
+                                output_img2img_params = gr.Highlightedtext(
+                                    label="Generation parameters", interactive=False,
+                                    elem_id='highlight')
                                 with gr.Row():
                                     output_img2img_copy_params = gr.Button("Copy full parameters").click(
                                         inputs=output_img2img_params, outputs=[],


### PR DESCRIPTION
# Description

Fix broken output info in img2img to highlight parameters like in txt2img.

* change gr.Textbox to gr.Highlightedtext like in txt2img

Closes: #1288 

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation