### PR TITLE
Remove wrong arguments from save_sample call - fixes 1258

### DIFF
--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -1284,8 +1284,7 @@ skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoisin
                         output_images.append( steps_grid.resize( gallery_img_size ) )
                     if job_info.rec_steps_to_file:
                         steps_grid_filename = f"{original_filename}_step_grid"
-                        save_sample(steps_grid, sample_path_i, steps_grid_filename, jpg_sample, prompts, seeds, width, height, steps, cfg_scale,
-                                    normalize_prompt_weights, use_GFPGAN, write_info_files, write_sample_info_to_log_file, prompt_matrix, init_img, uses_loopback, uses_random_seed_loopback, skip_save,
+                        save_sample(steps_grid, sample_path_i, steps_grid_filename, jpg_sample, write_info_files, write_sample_info_to_log_file, prompt_matrix, init_img, uses_loopback, uses_random_seed_loopback, skip_save,
                                     skip_grid, sort_samples, sampler_name, ddim_eta, n_iter, batch_size, i, denoising_strength, resize_mode, False)
 
             if opt.optimized:


### PR DESCRIPTION
# Description

Remove wrong arguments from save_sample call.

Closes: #1258

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation