### PR TITLE
lock down pip versions

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -21,10 +21,10 @@ dependencies:
     - -e git+https://github.com/devilismyfriend/latent-diffusion#egg=latent-diffusion
     - accelerate==0.12.0
     - albumentations==0.4.3
-    - basicsr>=1.3.4.0
+    - basicsr==1.3.4.0
     - diffusers==0.3.0
     - einops==0.3.0
-    - facexlib>=0.2.3
+    - facexlib==0.2.3
     - gradio==3.1.6
     - imageio-ffmpeg==0.4.2
     - imageio==2.9.0
@@ -35,15 +35,15 @@ dependencies:
     - piexif==1.1.3
     - pudb==2019.2
     - pynvml==11.4.1
-    - python-slugify>=6.1.2
+    - python-slugify==6.1.2
     - pytorch-lightning==1.4.2
-    - retry>=0.9.2
+    - retry==0.9.2
     - streamlit==1.12.2
     - streamlit-on-Hover-tabs==1.0.1
     - streamlit-option-menu==0.3.2
-    - streamlit_nested_layout
-    - test-tube>=0.7.5
-    - tensorboard
+    - streamlit_nested_layout==0.1.1
+    - test-tube==0.7.5
+    - tensorboard==2.10.0
     - torch-fidelity==0.3.0
     - torchmetrics==0.6.0
     - transformers==4.19.2


### PR DESCRIPTION
# Description

Fully lock the pip install versions for other remaining unspecified or `>=` versions. To avoid unexpected update issues.

Add on to : #1282

# Checklist:

- [X] I have changed the base branch to `dev`
- [X] I have performed a self-review of my own code
- [NA] I have commented my code in hard-to-understand areas
- [ NA] I have made corresponding changes to the documentation