### PR TITLE
fix broken parameter copy in img2img, fixes #1299

### DIFF
--- a/frontend/css_and_js.py
+++ b/frontend/css_and_js.py
@@ -25,7 +25,7 @@ def js(opt):
 
 
 # TODO : @altryne fix this to the new JS format
-js_copy_txt2img_output = "(x) => {navigator.clipboard.writeText(document.querySelector('gradio-app').shadowRoot.querySelector('#highlight .textfield').textContent.replace(/\s+/g,' ').replace(/: /g,':'))}"
+js_copy_txt2img_output = "(x) => {navigator.clipboard.writeText(document.querySelector('gradio-app').shadowRoot.querySelector('#highlight .textfield').textContent.replace(/\s+/g,' ').replace(/: /g,':')); return [];}"
 
 
 

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -252,8 +252,8 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                                     elem_id='highlight')
                                 with gr.Row():
                                     output_img2img_copy_params = gr.Button("Copy full parameters").click(
-                                        inputs=output_img2img_params, outputs=[],
-                                        _js='(x) => {navigator.clipboard.writeText(x.replace(": ",":"))}', fn=None,
+                                        inputs=[output_img2img_params], outputs=[],
+                                        _js=js_copy_txt2img_output, fn=None,
                                         show_progress=False)
                                     output_img2img_seed = gr.Number(label='Seed', interactive=False, visible=False)
                                     output_img2img_copy_seed = gr.Button("Copy only seed").click(


### PR DESCRIPTION
# Description

Copy full parameters in img2img was broken and copy full parameters in txt2img worked, but throwed a silent javascript error anyway.

Changes the javascript function for copying to `js_copy_txt2img_output`, the one used for txt2img parameter copy.
This function correctly copies highlighted text, but throws an javascript error into the web console for both txt2img and img2img. The error was caused by not returning an empty (update) list back to gradio.
To fix this the missing return value was added to the function.

Closes: #1299

Maybe it makes sense to rename the `js_copy_txt2img_output` to something like `js_copy_highlighted_output` to better reflect what it actually does. If wanted I could add this change as well, but it is not necessary for fixing the bugs.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation