### PR TITLE
removed cache and corrupted pngs try catch

### DIFF
--- a/scripts/sd_concept_library.py
+++ b/scripts/sd_concept_library.py
@@ -102,7 +102,7 @@ def getConceptsFromPath(page, conceptPerPage, searchText=""):
 					# Close original image
 					originalImage.close()
 				except:
-					print("Error with file", file, "in concept", folder, "skipping (file is probably corrupted)")
+					print("Error with file '", file, "' in concept '", folder, "', skipping. (file is probably corrupted)")
 
 		concepts.append(concept)
 		conceptIndex += 1

--- a/scripts/sd_concept_library.py
+++ b/scripts/sd_concept_library.py
@@ -1,9 +1,9 @@
 # base webui import and utils.
 from webui_streamlit import st
 from sd_utils import *
-import os, subprocess, shutil
-from huggingface_hub import HfApi
-from git import Repo, RemoteProgress
+# import os, subprocess, shutil
+# from huggingface_hub import HfApi
+# from git import Repo, RemoteProgress
 
 # streamlit imports
 import streamlit.components.v1 as components
@@ -230,11 +230,12 @@ def layout():
 
 
 	with tab_downloader:
-		api = HfApi()
-		models_list = api.list_models(author="sd-concepts-library", sort="alphabetical", direction=-1)
-		models = []
-		for model in models_list:
-			_col_name, _col_description, _col_downloads, _col_likes, _col_last_updated = st.columns([2, 4, 1, 1, 1])
-			st.write(model)
+		# api = HfApi()
+		# models_list = api.list_models(author="sd-concepts-library", sort="alphabetical", direction=-1)
+		# models = []
+		# for model in models_list:
+		# 	_col_name, _col_description, _col_downloads, _col_likes, _col_last_updated = st.columns([2, 4, 1, 1, 1])
+		# 	st.write(model)
+		st.write("Coming soon")
 
 	return False


### PR DESCRIPTION
**Removed caching to the listing of local dowloaded concepts.** 

The issue with using `@st.cache` on almost all function was that the librairy could still display files and previews images from concepts that weren't not present anymore, neither it would show newly added concepts. ( and even after reloading the app if `persist` was set to `true`)

This may have lower performance than caching everything, we need to figure out a way to have caching while still beeing able to add new concepts without reloading the app. 

**Moved the thumbnail handling into a try-except block**

The app does no longer crash when attempting to open corrupted png files. 
A print to the terminal will inform the user of the corrupted file.

`Error with file '1.jpeg' in concept 'accurate-angel', skipping. (file is probably corrupted)`

Closes: # (issue)

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas