### PR TITLE
Previews for checkpoints, speed increases

### DIFF
--- a/scripts/diffusers_textual_inversion_2.py
+++ b/scripts/diffusers_textual_inversion_2.py
@@ -182,12 +182,6 @@ def parse_args():
         default=None,
         help="Path to a specific checkpoint to resume training from (ie, logs/token_name/2022-09-22T23-36-27/checkpoints/something.bin)."
     )
-    parser.add_argument(
-        "--config",
-        type=str,
-        default=None,
-        help="Path to a JSON config file specifying the arguments to use. If resume_from is given, it is automatically inferred."
-    )
 
     args = parser.parse_args()
     if args.config is not None:


### PR DESCRIPTION
# Description

This builds on the previous work I'd done in the v2 trainer. All in all, with the changes to image caching and autoencoding of images, my training times at 512x512 went from 1.5 it/s to 2.2 it/s, a 40% improvement. 

* Restore --config. This will be useful when you have an init config that you don't want overwritten.
* Cache the individual transformed images in TextualInversionDataset. This gains speed by avoiding reading and reprocessing the image each time it's used for training.
* Turn on no_grad for inference and clean up tensors during checkpointing. This reduces memory usage slightly.
* Set the sample output size to 384x384. We just need them large enough for manual evaluation, and this gains us a decent chunk of speed.
* (breaking change) Custom templates are now semicolon-delineated. Additionally, custom templates are properly passed through to TextualInversionDataset to generate input_ids for your images. Using custom templates which accurately describe your input images seems to improve training fidelity.
* Cache autoencoding of image pixel data. This substantially increases the speed of training, upwards of 40% for me.
* Clean up a little bit of cruft.
   
# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation