### PR TITLE
Block Streamlit Usage Stats and Telemetry Gathering

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[browser]
+gatherUsageStats = false


### PR DESCRIPTION
# Block Streamlit Usage Stats and Telemetry Gathering

By default, Streamlit collects usage statistics and telemetry. See [Streamlit Privacy Policy](https://streamlit.io/privacy-policy)

This implementation disables usage statistics collection and applies when running the SD WebGUI via Streamlit from the `sd` directory.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation