### PR TITLE
Added source to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-models/
+models/custom/
 outputs/
 src/
 gfpgan/

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,14 @@ COPY /data/DejaVuSans.ttf /usr/share/fonts/truetype/
 
 ENV PYTHONPATH=/sd
 
+COPY ./models /sd/models
+COPY ./configs /sd/configs
+COPY ./frontend /sd/frontend
+COPY ./ldm /sd/ldm
+# COPY ./gfpgan/ /sd/
+COPY ./optimizedSD /sd/optimizedSD
+COPY ./scripts /sd/scripts
+
 EXPOSE 7860 8501
 
 COPY ./entrypoint.sh /sd/


### PR DESCRIPTION
# Description
This will allow the image to be used outside of the repo (such as in a service like runpod, or by a novice user who doesn't want to pull the git repo and instead use `docker run ...`) once we start pushing the images to Docker Hub.

Closes: Nothing, yet. This is a step in the direction of `#installation-packing:Docker` in Discord.

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation