### PR TITLE
Changed realesrgan dependency to use pip instead.

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -33,7 +33,6 @@ dependencies:
     - -e git+https://github.com/CompVis/taming-transformers#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP#egg=clip
     - -e git+https://github.com/TencentARC/GFPGAN#egg=GFPGAN
-    - -e git+https://github.com/xinntao/Real-ESRGAN#egg=realesrgan
     - -e git+https://github.com/hlky/k-diffusion-sd#egg=k_diffusion
     - -e git+https://github.com/devilismyfriend/latent-diffusion#egg=latent-diffusion
     - accelerate==0.12.0
@@ -55,6 +54,7 @@ dependencies:
     - python-slugify>=6.1.2
     - pytorch-lightning==1.4.2
     - retry>=0.9.2
+    - realesrgan==0.3.0
     - streamlit==1.13.0
     - streamlit-on-Hover-tabs==1.0.1
     - streamlit-option-menu==0.3.2


### PR DESCRIPTION
Changed realesrgan dependency to use pip instead of having to clone the repository on the src folder, this should reduce the amount of stuff that is on the src folder and that causes issues when updating.

# Checklist:

- [x ] I have changed the base branch to `dev`
- [ x] I have performed a self-review of my own code