### PR TITLE
Revert "Bump numpy from 1.21.5 to 1.22.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Minimum Environment Dependencies for Stable Diffusion
 #torch  # already satisfied as 1.12.1 from base image
 #torchvision  # already satisfied as 0.13.1 from base image
-numpy==1.22.0  # already satisfied as 1.21.5 from base image
+numpy==1.21.5  # already satisfied as 1.21.5 from base image
 
 
 # Stable Diffusion (see: https://github.com/CompVis/stable-diffusion)


### PR DESCRIPTION
This reverts commit 2d0a4e8e96405ddc856da045e01748bf76071ad5, reversing changes made to 1190d8858cdbd63f968572eeee07657ec76a6574.