### PR TITLE
Settings and defaults for upscaling

### DIFF
--- a/scripts/Settings.py
+++ b/scripts/Settings.py
@@ -92,7 +92,8 @@ def layout():
 				st.session_state['defaults'].general.RealESRGAN_model = st.selectbox("RealESRGAN model", RealESRGAN_model_list,
 																					 index=RealESRGAN_model_list.index(st.session_state['defaults'].general.RealESRGAN_model),
 																					 help="Default RealESRGAN model. Default: 'RealESRGAN_x4plus'")
-				
+				Upscaler_list = ["RealESRGAN", "LDSR"]
+				st.session_state['defaults'].general.upscaling_method = st.selectbox("Upscaler", Upscaler_list, index=Upscaler_list.index(st.session_state['defaults'].general.upscaling_method), help="Default upscaling method. Default: 'RealESRGAN'")
 
 			with col2:
 				st.title("Performance")	
@@ -325,8 +326,8 @@ def layout():
 
 				st.session_state["defaults"].txt2img.use_GFPGAN = st.checkbox("Use GFPGAN", value=st.session_state['defaults'].txt2img.use_GFPGAN, help="Choose to use GFPGAN. Default: False")
     
-				st.session_state["defaults"].txt2img.use_RealESRGAN = st.checkbox("Use RealESRGAN", value=st.session_state['defaults'].txt2img.use_RealESRGAN, 
-																				  help="Choose to use RealESRGAN. Default: False")
+				st.session_state["defaults"].txt2img.use_upscaling = st.checkbox("Use Upscaling", value=st.session_state['defaults'].txt2img.use_upscaling, 
+																				  help="Choose to turn on upscaling by default. Default: False")
     
 				st.session_state["defaults"].txt2img.update_preview = True
 				st.session_state["defaults"].txt2img.update_preview_frequency = int(st.text_input("Preview Image Update Frequency",

--- a/scripts/sd_utils.py
+++ b/scripts/sd_utils.py
@@ -405,7 +405,7 @@ class MemUsageMonitor(threading.Thread):
         except:
             print(f"[{self.name}] Unable to initialize NVIDIA management. No memory stats. \n")
             return
-        print(f"[{self.name}] Recording max memory usage...\n")
+        print(f"[{self.name}] Recording memory usage...\n")
         # Missing context
         #handle = pynvml.nvmlDeviceGetHandleByIndex(st.session_state['defaults'].general.gpu)
         handle = pynvml.nvmlDeviceGetHandleByIndex(0)

--- a/scripts/txt2img.py
+++ b/scripts/txt2img.py
@@ -326,7 +326,7 @@ def layout():
                                 st.session_state["use_GFPGAN"] = False                                 
                             
                         with upscaling_tab:
-                            st.session_state['us_upscaling'] = st.checkbox("Use Upscaling", value=st.session_state['defaults'].txt2img.use_upscaling)
+                            st.session_state['use_upscaling'] = st.checkbox("Use Upscaling", value=st.session_state['defaults'].txt2img.use_upscaling)
                             
                             # RealESRGAN and LDSR used for upscaling.     
                             if st.session_state["RealESRGAN_available"] or st.session_state["LDSR_available"]:
@@ -343,7 +343,7 @@ def layout():
                                 
                                 if st.session_state["RealESRGAN_available"]:
                                     with st.expander("RealESRGAN"):
-                                        if st.session_state["upscaling_method"] == "RealESRGAN" and st.session_state['us_upscaling']:
+                                        if st.session_state["upscaling_method"] == "RealESRGAN" and st.session_state['use_upscaling']:
                                             st.session_state["use_RealESRGAN"] = True
                                         else:
                                             st.session_state["use_RealESRGAN"] = False
@@ -358,7 +358,7 @@ def layout():
                                 #
                                 if st.session_state["LDSR_available"]:
                                     with st.expander("LDSR"):
-                                        if st.session_state["upscaling_method"] == "LDSR" and st.session_state['us_upscaling']:
+                                        if st.session_state["upscaling_method"] == "LDSR" and st.session_state['use_upscaling']:
                                             st.session_state["use_LDSR"] = True
                                         else:
                                             st.session_state["use_LDSR"] = False


### PR DESCRIPTION
-Changes wording on Memory Monitor to not alarm users (happened a few times) 
-Adds config settings "use_upscaling" and "upscaling_method" to settings menu, were already in yaml
