### PR TITLE
fix type error

### DIFF
--- a/scripts/Settings.py
+++ b/scripts/Settings.py
@@ -270,7 +270,7 @@ def layout():
 																									  value=st.session_state['defaults'].txt2img.sampling_steps.min_value,
 																									  help="Set the default minimum value for the sampling steps slider. Default is: 1")
 
-					st.session_state["defaults"].txt2img.sampling_steps.step = st.text_input("Sampling Slider Steps",
+					st.session_state["defaults"].txt2img.sampling_steps.step = st.number_input("Sampling Slider Steps",
 																								 value=st.session_state['defaults'].txt2img.sampling_steps.step,
 																								 help="Set the default value for the number of steps on the sampling steps slider. Default is: 10")
 


### PR DESCRIPTION
# Description

hopefully fixes
```
StreamlitAPIException: All numerical arguments must be of the same type. value has int type. min_value has int type. max_value has NoneType type. step has str type.
Traceback:

File "/home/chris/stable2/sd-web/stable-diffusion-webui/scripts/webui_streamlit.py", line 177, in <module>
    layout()
File "/home/chris/stable2/sd-web/stable-diffusion-webui/scripts/webui_streamlit.py", line 141, in layout
    layout()
File "scripts/txt2img.py", line 267, in layout
    st.session_state.sampling_steps = st.number_input("Sampling Steps", value=st.session_state.defaults.txt2img.sampling_steps.value,
```
for some users


Fixes #1456

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation