### PR TITLE
Skip WebUI prompt if --bridge passed, Detailed error messages if bridgeData.py fails to load

### DIFF
--- a/horde_bridge.sh
+++ b/horde_bridge.sh
@@ -162,7 +162,7 @@ start_initialization () {
         echo "Your model file does not exist! Place it in 'models/ldm/stable-diffusion-v1' with the name 'model.ckpt'."
         exit 1
     fi
-    printf "\nStarting Stable Horde Bridg: Please Wait...\n"; python scripts/relauncher.py --bridge -v "$@"; break;
+    printf "\nStarting Stable Horde Bridge: Please Wait...\n"; python scripts/relauncher.py --bridge -v "$@"; break;
 
 }
 

--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -2783,22 +2783,33 @@ if __name__ == '__main__':
     if opt.bridge:
         try:
             import bridgeData as cd
-        except:
+        except ModuleNotFoundError as e:
+            logger.warning("No bridgeData found. Falling back to default where no CLI args are set.")
+            logger.warning(str(e))
+        except SyntaxError as e:
+            logger.warning("bridgeData found, but is malformed. Falling back to default where no CLI args are set.")
+            logger.warning(str(e))
+        except Exception as e:
             logger.warning("No bridgeData found, use default where no CLI args are set")
-            class temp(object):
-                def __init__(self):
-                    random.seed()
-                    self.horde_url = "https://stablehorde.net"
-                    # Give a cool name to your instance
-                    self.horde_name = f"Automated Instance #{random.randint(-100000000, 100000000)}"
-                    # The api_key identifies a unique user in the horde
-                    self.horde_api_key = "0000000000"
-                    # Put other users whose prompts you want to prioritize.
-                    # The owner's username is always included so you don't need to add it here, unless you want it to have lower priority than another user
-                    self.horde_priority_usernames = []
-                    self.horde_max_power = 8
-                    self.nsfw = True
-            cd = temp()
+            logger.warning(str(e))
+        finally:
+            try: # check if cd exists (i.e. bridgeData loaded properly)
+                cd
+            except: # if not, create defaults
+                class temp(object):
+                    def __init__(self):
+                        random.seed()
+                        self.horde_url = "https://stablehorde.net"
+                        # Give a cool name to your instance
+                        self.horde_name = f"Automated Instance #{random.randint(-100000000, 100000000)}"
+                        # The api_key identifies a unique user in the horde
+                        self.horde_api_key = "0000000000"
+                        # Put other users whose prompts you want to prioritize.
+                        # The owner's username is always included so you don't need to add it here, unless you want it to have lower priority than another user
+                        self.horde_priority_usernames = []
+                        self.horde_max_power = 8
+                        self.nsfw = True
+                cd = temp()
         horde_api_key = opt.horde_api_key if opt.horde_api_key else cd.horde_api_key
         horde_name = opt.horde_name if opt.horde_name else cd.horde_name
         horde_url = opt.horde_url if opt.horde_url else cd.horde_url

--- a/webui.sh
+++ b/webui.sh
@@ -154,6 +154,13 @@ post_processor_model_loading () {
 
 # Show the user a prompt asking them which version of the WebUI they wish to use, Streamlit or Gradio
 launch_webui () {
+    # skip the prompt if --bridge command-line argument is detected
+    for arg in "$@"; do
+        if [ "$arg" == "--bridge" ]; then
+           python -u scripts/relauncher.py "$@"
+           return
+        fi
+    done
     printf "\n\n########## LAUNCH USING STREAMLIT OR GRADIO? ##########\n\n"
     printf "Do you wish to run the WebUI using the Gradio or StreamLit Interface?\n\n"
     printf "Streamlit: \nHas A More Modern UI \nMore Features Planned \nWill Be The Main UI Going Forward \nCurrently In Active Development \nMissing Some Gradio Features\n\n"


### PR DESCRIPTION
# Description

Please include:
- [x] relevant motivation
- [x] a summary of the change
- [ ] which issue is fixed.
- [x] any additional dependencies that are required for this change.

Fixes a small typo of "Bridg" in horde_bridge.sh
Makes webui.sh skip asking for StreamLit/Gradio if --bridge is passed
More detailed error messages if bridgeData.py is missing/malformed (previously it would only say no bridgeData found, which caused confusion when bridgeData did exist but was incorrectly formatted)

# Checklist:

- [x] I have changed the base branch to `dev`
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation