### PR TITLE
chore: bump Gradio to 3.4.1

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -88,3 +88,11 @@ input[type=number]:disabled { -moz-appearance: textfield; }
     /* fix buttons layouts */
 
 }
+
+/* Gradio 3.4 FIXES */
+#prompt_row button {
+    max-width: 20ch;
+}
+#text2img_col2 {
+    flex-grow: 2 !important;
+}

--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -65,7 +65,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
 
                         txt2img_dimensions_info_text_box = gr.Textbox(
                             label="Aspect ratio (4:3 = 1.333 | 16:9 = 1.777 | 21:9 = 2.333)")
-                    with gr.Column():
+                    with gr.Column(elem_id="text2img_col2"):
                         with gr.Box():
                             output_txt2img_gallery = gr.Gallery(label="Images", elem_id="txt2img_gallery_output").style(
                                 grid=[4, 4])
@@ -312,7 +312,7 @@ def draw_gradio_ui(opt, img2img=lambda x: x, txt2img=lambda x: x, imgproc=lambda
                                                         label='Batch count (how many batches of images to generate)',
                                                         value=img2img_defaults['n_iter'])
                         img2img_dimensions_info_text_box = gr.Textbox(
-                            label="Aspect ratio (4:3 = 1.333 | 16:9 = 1.777 | 21:9 = 2.333)")
+                            label="Aspect ratio (4:3 = 1.333 | 16:9 = 1.777 | 21:9 = 2.333)", lines="2")
                     with gr.Column():
                         img2img_steps = gr.Slider(minimum=1, maximum=250, step=1, label="Sampling Steps",
                                                   value=img2img_defaults['ddim_steps'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ omegaconf==2.2.3
 Jinja2==3.1.2  # Jinja2 is required by Gradio
 
 # Environment Dependencies for WebUI (gradio)
-gradio==3.1.6
+gradio==3.4.1
 
 # Environment Dependencies for WebUI (streamlit)
 streamlit==1.13.0


### PR DESCRIPTION
* update gradio
* fix some glaring styling issues

Note: the server message has changed and now the address `0.0.0.0:7680` is shown by default which might not work in browsers. The server is still accessible through `localhost`/real ip address