### PR TITLE
Don't ask about restoring stash if nothing was stashed

### DIFF
--- a/horde_bridge.cmd
+++ b/horde_bridge.cmd
@@ -65,11 +65,13 @@ IF "%HasChanges%" == "0" GOTO SKIP_RESTORE
 
 set /P restore="Do you want to restore changes you made before updating? (Y/N): "
 IF /I "%restore%" == "N" (
-  echo Removing changes please wait...
+  echo Removing changes...
   call git stash drop
+  echo "Changes removed"
 ) ELSE IF /I "%restore%" == "Y" (
-  echo Restoring changes, please wait...
+  echo Restoring changes...
   call git stash pop --quiet
+  echo "Changes restored"
 )
 
 :SKIP_RESTORE

--- a/horde_bridge.cmd
+++ b/horde_bridge.cmd
@@ -58,20 +58,21 @@ IF "%v_conda_path%"=="" (
 
 :CONDA_FOUND
 echo Stashing local changes and pulling latest update...
+git status --porcelain=1 -uno | findstr . && set "HasChanges=1" || set "HasChanges=0"
 call git stash
 call git pull
+IF "%HasChanges%" == "0" GOTO SKIP_RESTORE
+
 set /P restore="Do you want to restore changes you made before updating? (Y/N): "
 IF /I "%restore%" == "N" (
   echo Removing changes please wait...
   call git stash drop
-  echo Changes removed, press any key to continue...
-  pause >nul
 ) ELSE IF /I "%restore%" == "Y" (
   echo Restoring changes, please wait...
   call git stash pop --quiet
-  echo Changes restored, press any key to continue...
-  pause >nul
 )
+
+:SKIP_RESTORE
 call "%v_conda_path%\Scripts\activate.bat"
 
 for /f "delims=" %%a in ('git log -1 --format^="%%H" -- environment.yaml')  DO set v_cur_hash=%%a

--- a/webui-streamlit.cmd
+++ b/webui-streamlit.cmd
@@ -65,11 +65,13 @@ IF "%HasChanges%" == "0" GOTO SKIP_RESTORE
 
 set /P restore="Do you want to restore changes you made before updating? (Y/N): "
 IF /I "%restore%" == "N" (
-  echo Removing changes please wait...
+  echo Removing changes...
   call git stash drop
+  echo Changes removed
 ) ELSE IF /I "%restore%" == "Y" (
-  echo Restoring changes, please wait...
+  echo Restoring changes...
   call git stash pop --quiet
+  echo Changes restored
 )
 
 :SKIP_RESTORE

--- a/webui-streamlit.cmd
+++ b/webui-streamlit.cmd
@@ -58,20 +58,21 @@ IF "%v_conda_path%"=="" (
 
 :CONDA_FOUND
 echo Stashing local changes and pulling latest update...
+git status --porcelain=1 -uno | findstr . && set "HasChanges=1" || set "HasChanges=0"
 call git stash
 call git pull
+IF "%HasChanges%" == "0" GOTO SKIP_RESTORE
+
 set /P restore="Do you want to restore changes you made before updating? (Y/N): "
 IF /I "%restore%" == "N" (
   echo Removing changes please wait...
   call git stash drop
-  echo Changes removed, press any key to continue...
-  pause >nul
 ) ELSE IF /I "%restore%" == "Y" (
   echo Restoring changes, please wait...
   call git stash pop --quiet
-  echo Changes restored, press any key to continue...
-  pause >nul
 )
+
+:SKIP_RESTORE
 call "%v_conda_path%\Scripts\activate.bat"
 
 for /f "delims=" %%a in ('git log -1 --format^="%%H" -- environment.yaml')  DO set v_cur_hash=%%a

--- a/webui.cmd
+++ b/webui.cmd
@@ -65,11 +65,13 @@ IF "%HasChanges%" == "0" GOTO SKIP_RESTORE
 
 set /P restore="Do you want to restore changes you made before updating? (Y/N): "
 IF /I "%restore%" == "N" (
-  echo Removing changes please wait...
+  echo Removing changes...
   call git stash drop
+  echo Changes removed
 ) ELSE IF /I "%restore%" == "Y" (
-  echo Restoring changes, please wait...
+  echo Restoring changes...
   call git stash pop --quiet
+  echo Changes restored
 )
 
 :SKIP_RESTORE

--- a/webui.cmd
+++ b/webui.cmd
@@ -58,20 +58,21 @@ IF "%v_conda_path%"=="" (
 
 :CONDA_FOUND
 echo Stashing local changes and pulling latest update...
+git status --porcelain=1 -uno | findstr . && set "HasChanges=1" || set "HasChanges=0"
 call git stash
 call git pull
+IF "%HasChanges%" == "0" GOTO SKIP_RESTORE
+
 set /P restore="Do you want to restore changes you made before updating? (Y/N): "
 IF /I "%restore%" == "N" (
   echo Removing changes please wait...
   call git stash drop
-  echo Changes removed, press any key to continue...
-  pause >nul
 ) ELSE IF /I "%restore%" == "Y" (
   echo Restoring changes, please wait...
   call git stash pop --quiet
-  echo Changes restored, press any key to continue...
-  pause >nul
 )
+
+:SKIP_RESTORE
 call "%v_conda_path%\Scripts\activate.bat"
 
 for /f "delims=" %%a in ('git log -1 --format^="%%H" -- environment.yaml')  DO set v_cur_hash=%%a


### PR DESCRIPTION
# Description

Minor quality of life update.

Recently launching the webui.bat became a bit more annoying, as it always asks about restoring changes, even if I have none, and then it needs another interaction for no reason (pause>nul).

This change makes sure the interaction is only needed when there were changes stashed, and removes the second pause.

Yesterday I double clicked the shortcut to start the Stable Horde worker overnight, and even noticed the "Y/N" prompt, but went to bed not realizing it also does the (pause>nul) after that... No reason to be this intrusive.

Closes: #1532

# Checklist:

- [X] I have changed the base branch to `dev`
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation