### PR TITLE
feat: revert Dockerfile to use GradIO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=hlky/sd-webui:base
+ARG IMAGE=digburn/sd-webui:base
 
 FROM ${IMAGE}
 
@@ -8,18 +8,14 @@ SHELL ["/bin/bash", "-c"]
 
 ENV PYTHONPATH=/sd
 
-EXPOSE 8501
+EXPOSE 7860
 COPY ./data/DejaVuSans.ttf /usr/share/fonts/truetype/
 COPY ./data/ /sd/data/
-copy ./images/ /sd/images/
-copy ./scripts/ /sd/scripts/
-copy ./ldm/ /sd/ldm/
-copy ./frontend/ /sd/frontend/
-copy ./configs/ /sd/configs/
-copy ./.streamlit/ /sd/.streamlit/
-COPY ./entrypoint.sh /sd/
+COPY ./images/ /sd/images/
+COPY ./scripts/ /sd/scripts/
+COPY ./ldm/ /sd/ldm/
+COPY ./frontend/ /sd/frontend/
+COPY ./configs/ /sd/configs/
+COPY ./runpod_entrypoint.sh /sd/entrypoint.sh
+RUN chmod +x /sd/entrypoint.sh
 ENTRYPOINT /sd/entrypoint.sh
-
-RUN mkdir -p ~/.streamlit/
-RUN echo "[general]"  > ~/.streamlit/credentials.toml
-RUN echo "email = \"\""  >> ~/.streamlit/credentials.toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e .
+# -e .
 
 # See: https://github.com/CompVis/taming-transformers/issues/176
 # -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers # required by ldm

--- a/runpod_entrypoint.sh
+++ b/runpod_entrypoint.sh
@@ -37,8 +37,6 @@ then
 fi
 
 cd $SCRIPT_DIR
-launch_command="streamlit run ${SCRIPT_DIR}/scripts/webui_streamlit.py"
+launch_command="python ${SCRIPT_DIR}/scripts/webui.py"
 
 $launch_command
-
-sleep infinity

--- a/scripts/webui.py
+++ b/scripts/webui.py
@@ -386,7 +386,7 @@ def load_LDSR(checking=False):
     LDSRObject = LDSR(model_path, yaml_path)
     return LDSRObject
 def load_GFPGAN(checking=False):
-    model_name = 'GFPGANv1.3'
+    model_name = 'GFPGANv1.4'
     model_path = os.path.join(GFPGAN_dir, model_name + '.pth')
     if not os.path.isfile(model_path):
         raise Exception("GFPGAN model not found at path "+model_path)


### PR DESCRIPTION
This is because GradIO provides a REST API, which we need to use SD as a service.

# Description

Please include:
* relevant motivation
* a summary of the change
* which issue is fixed.
* any additional dependencies that are required for this change.

Closes: # (issue)

# Checklist:

- [ ] I have changed the base branch to `dev`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation